### PR TITLE
Make the jenkinsfile able to test both channels

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,11 @@ def genVerifyJob(String t) {
     stage("${t}") {
       wrappedNode(label: 'aufs', cleanWorkspace: true) {
         checkout scm
-        sh("make clean ${t}.log")
+        channel = 'test'
+        if ("${env.JOB_NAME}".endsWith('get.docker.com')) {
+            channel='edge'
+        }
+        sh("make CHANNEL_TO_TEST=${channel} clean ${t}.log")
         archiveArtifacts '*.log'
       }
     }


### PR DESCRIPTION
Makes the jenkinsfile able to test both channels.

This is definitely a temporary fix until docker/release#245 can get resolved, in which case we will just automate the tests and test both edge and test at the same time.