### PR TITLE
Make testing working again!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-*.log
+verify-install-*
 build/

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 SHELL:=/bin/bash
-VERIFY_INSTALL_DISTROS:=$(addprefix verify-install-,centos-7 fedora-24 fedora-25 debian-wheezy debian-jessie debian-stretch ubuntu-trusty ubuntu-xenial ubuntu-yakkety ubuntu-zesty)
+DISTROS:=centos-7 fedora-24 fedora-25 debian-wheezy debian-jessie debian-stretch ubuntu-trusty ubuntu-xenial ubuntu-yakkety ubuntu-zesty
+VERIFY_INSTALL_DISTROS:=$(addprefix verify-install-,$(DISTROS))
 CHANNEL_TO_TEST?=test
 EXPECTED_VERSION?=
 EXPECTED_GITCOMMIT?=
@@ -26,9 +27,9 @@ check: $(VERIFY_INSTALL_DISTROS)
 
 .PHONY: clean
 clean:
-	$(RM) *.log
+	$(RM) verify-install-*
 
-verify-install-%.log: needs_version needs_gitcommit
+verify-install-%: needs_version needs_gitcommit
 	mkdir -p build
 	sed 's/DEFAULT_CHANNEL_VALUE="test"/DEFAULT_CHANNEL_VALUE="$(CHANNEL_TO_TEST)"/' install.sh > build/install.sh
 	set -o pipefail && docker run \


### PR DESCRIPTION
.log files didn't work correctly when evaluating possible docker images
to run so I removed the suffix portion. Also made it easier to run for
specific distros ala:

`make DISTROS="fedora-25 fedora-24 centos-7" CHANNEL_TO_TEST=edge EXPECTED_VERSION="17.06.0-ce" EXPECTED_GITCOMMIT="02c1d87" clean check`

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>