### PR TITLE
Removes version and git commit verification

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,13 +1,4 @@
 #!groovy
-properties(
-  [
-    buildDiscarder(logRotator(numToKeepStr: '20')),
-    parameters([
-      string(defaultValue: '', description: 'Expected docker version output of --version flag.', name: 'EXPECTED_VERSION'),
-      string(defaultValue: '', description: 'Expected docker gitcommit output of --version flag.', name: 'EXPECTED_GITCOMMIT'),
-    ])
-  ]
-)
 
 def verifyTargets = [
   'verify-install-centos-7',
@@ -31,8 +22,8 @@ def genVerifyJob(String t) {
         if ("${env.JOB_NAME}".endsWith('get.docker.com')) {
             channel='edge'
         }
-        sh("make CHANNEL_TO_TEST=${channel} clean ${t}.log")
-        archiveArtifacts '*.log'
+        sh("make CHANNEL_TO_TEST=${channel} clean ${t}")
+        archiveArtifacts 'verify-install-*'
       }
     }
   } ]

--- a/Makefile
+++ b/Makefile
@@ -2,21 +2,7 @@ SHELL:=/bin/bash
 DISTROS:=centos-7 fedora-24 fedora-25 debian-wheezy debian-jessie debian-stretch ubuntu-trusty ubuntu-xenial ubuntu-yakkety ubuntu-zesty
 VERIFY_INSTALL_DISTROS:=$(addprefix verify-install-,$(DISTROS))
 CHANNEL_TO_TEST?=test
-EXPECTED_VERSION?=
-EXPECTED_GITCOMMIT?=
 SHELLCHECK=shellcheck
-
-.PHONY: needs_version
-needs_version:
-ifndef EXPECTED_VERSION
-	$(error EXPECTED_VERSION is undefined)
-endif
-
-.PHONY: needs_gitcommit
-needs_gitcommit:
-ifndef EXPECTED_GITCOMMIT
-	$(error EXPECTED_GITCOMMIT is undefined)
-endif
 
 .PHONY: shellcheck
 shellcheck:
@@ -29,7 +15,7 @@ check: $(VERIFY_INSTALL_DISTROS)
 clean:
 	$(RM) verify-install-*
 
-verify-install-%: needs_version needs_gitcommit
+verify-install-%:
 	mkdir -p build
 	sed 's/DEFAULT_CHANNEL_VALUE="test"/DEFAULT_CHANNEL_VALUE="$(CHANNEL_TO_TEST)"/' install.sh > build/install.sh
 	set -o pipefail && docker run \
@@ -37,4 +23,4 @@ verify-install-%: needs_version needs_gitcommit
 		-v $(CURDIR):/v \
 		-w /v \
 		$(subst -,:,$*) \
-		/v/verify-docker-install "$(EXPECTED_VERSION)" "$(EXPECTED_GITCOMMIT)" | tee $@
+		/v/verify-docker-install | tee $@

--- a/verify-docker-install
+++ b/verify-docker-install
@@ -1,29 +1,21 @@
 #!/bin/bash -e
-expected_version=$1
-expected_gitcommit=$2
 (
-	echo "Executing installation script!"
+	echo "INFO: Executing installation script!"
 	sh build/install.sh
 )
-docker_version=$(docker --version)
-if [ $? -ne 0 ]; then
+
+# Verify that we can at least get version output
+if ! docker --version; then
 	echo "ERROR: Did Docker get installed?"
-	exit 3
-fi
-installed_version=$(echo $docker_version | awk '{print$3}')
-installed_gitcommit=$(echo $docker_version | awk '{print$5}')
-echo $docker_version
-echo -n "Checking if installed version '$installed_version' matches '$expected_version'... "
-if [[ "$installed_version" =~ "$expected_version" ]]; then
-	echo "PASSED!"
-else
-	echo "FAILED!"
 	exit 1
 fi
-echo -n "Checking if installed gitcommit '$installed_gitcommit' matches '$expected_gitcommit'... "
-if [[ "$installed_gitcommit" =~ "$expected_gitcommit" ]]; then
-	echo "PASSED!"
-else
-	echo "FAILED!"
-	exit 2
+
+# Attempt to run a container if not in a container
+if [ ! -f /.dockerenv  ]; then
+	if ! docker run --rm hello-world; then
+		echo "ERROR: Could not get docker to run the hello world container"
+		exit 2
+	fi
 fi
+
+echo "INFO: Successfully verified docker installation!"


### PR DESCRIPTION
The install script won't be updated every single time a release is done
so it does not make sense to tie the verification jobs to specific
versions / git commits.

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>