### PR TITLE
Updates for 17.07.0-ce-rc1

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,14 +9,31 @@ def verifyTargets = [
   'verify-install-debian-stretch',
   'verify-install-ubuntu-trusty',
   'verify-install-ubuntu-xenial',
-  'verify-install-ubuntu-yakkety',
   'verify-install-ubuntu-zesty',
 ]
 
-def genVerifyJob(String t) {
+def armhfverifyTargets = [
+  'armhf-verify-install-raspbian-jessie',
+  'armhf-verify-install-debian-jessie',
+  'armhf-verify-install-debian-stretch',
+  'armhf-verify-install-ubuntu-trusty',
+  'armhf-verify-install-ubuntu-xenial',
+  'armhf-verify-install-ubuntu-zesty',
+]
+
+def s390xverifyTargets = [
+  's390x-verify-install-ubuntu-xenial',
+  's390x-verify-install-ubuntu-zesty',
+]
+
+def aarch64verifyTargets = [
+  'aarch64-verify-install-ubuntu-xenial',
+]
+
+def genVerifyJob(String t, String label) {
   return [ "${t}" : { ->
     stage("${t}") {
-      wrappedNode(label: 'aufs', cleanWorkspace: true) {
+      wrappedNode(label: label, cleanWorkspace: true) {
         checkout scm
         channel = 'test'
         if ("${env.JOB_NAME}".endsWith('get.docker.com')) {
@@ -31,7 +48,19 @@ def genVerifyJob(String t) {
 
 def verifyJobs = [:]
 for (t in verifyTargets) {
-  verifyJobs << genVerifyJob(t)
+  verifyJobs << genVerifyJob(t, 'aufs')
+}
+
+for (t in armhfverifyTargets) {
+  verifyJobs << genVerifyJob(t, 'armhf')
+}
+
+for (t in s390xverifyTargets) {
+  verifyJobs << genVerifyJob(t, 's390x')
+}
+
+for (t in aarch64verifyTargets) {
+  verifyJobs << genVerifyJob(t, 'aarch64')
 }
 
 parallel(verifyJobs)

--- a/Makefile
+++ b/Makefile
@@ -24,3 +24,43 @@ verify-install-%:
 		-w /v \
 		$(subst -,:,$*) \
 		/v/verify-docker-install | tee $@
+
+armhf-verify-install-raspbian-jessie:
+	mkdir -p build
+	sed 's/DEFAULT_CHANNEL_VALUE="test"/DEFAULT_CHANNEL_VALUE="$(CHANNEL_TO_TEST)"/' install.sh > build/install.sh
+	set -o pipefail && docker run \
+		--rm \
+		-v $(CURDIR):/v \
+		-w /v \
+		resin/rpi-raspbian:jessie \
+		/v/verify-docker-install | tee $@
+
+armhf-verify-install-%:
+	mkdir -p build
+	sed 's/DEFAULT_CHANNEL_VALUE="test"/DEFAULT_CHANNEL_VALUE="$(CHANNEL_TO_TEST)"/' install.sh > build/install.sh
+	set -o pipefail && docker run \
+		--rm \
+		-v $(CURDIR):/v \
+		-w /v \
+		arm32v7/$(subst -,:,$*) \
+		/v/verify-docker-install | tee $@
+
+aarch64-verify-install-%:
+	mkdir -p build
+	sed 's/DEFAULT_CHANNEL_VALUE="test"/DEFAULT_CHANNEL_VALUE="$(CHANNEL_TO_TEST)"/' install.sh > build/install.sh
+	set -o pipefail && docker run \
+		--rm \
+		-v $(CURDIR):/v \
+		-w /v \
+		arm64v8/$(subst -,:,$*) \
+		/v/verify-docker-install | tee $@
+
+s390x-verify-install-%:
+	mkdir -p build
+	sed 's/DEFAULT_CHANNEL_VALUE="test"/DEFAULT_CHANNEL_VALUE="$(CHANNEL_TO_TEST)"/' install.sh > build/install.sh
+	set -o pipefail && docker run \
+		--rm \
+		-v $(CURDIR):/v \
+		-w /v \
+		s390x/$(subst -,:,$*) \
+		/v/verify-docker-install | tee $@

--- a/install.sh
+++ b/install.sh
@@ -28,100 +28,32 @@ if [ -z "$CHANNEL" ]; then
     CHANNEL=$DEFAULT_CHANNEL_VALUE
 fi
 
-#TODO: Remove this once raspian support is added to https://download.docker.com
-apt_url="https://apt.dockerproject.org"
-#yum_url="https://yum.dockerproject.org"
-
-docker_key="-----BEGIN PGP PUBLIC KEY BLOCK-----
-Version: GnuPG v1
-
-mQINBFWln24BEADrBl5p99uKh8+rpvqJ48u4eTtjeXAWbslJotmC/CakbNSqOb9o
-ddfzRvGVeJVERt/Q/mlvEqgnyTQy+e6oEYN2Y2kqXceUhXagThnqCoxcEJ3+KM4R
-mYdoe/BJ/J/6rHOjq7Omk24z2qB3RU1uAv57iY5VGw5p45uZB4C4pNNsBJXoCvPn
-TGAs/7IrekFZDDgVraPx/hdiwopQ8NltSfZCyu/jPpWFK28TR8yfVlzYFwibj5WK
-dHM7ZTqlA1tHIG+agyPf3Rae0jPMsHR6q+arXVwMccyOi+ULU0z8mHUJ3iEMIrpT
-X+80KaN/ZjibfsBOCjcfiJSB/acn4nxQQgNZigna32velafhQivsNREFeJpzENiG
-HOoyC6qVeOgKrRiKxzymj0FIMLru/iFF5pSWcBQB7PYlt8J0G80lAcPr6VCiN+4c
-NKv03SdvA69dCOj79PuO9IIvQsJXsSq96HB+TeEmmL+xSdpGtGdCJHHM1fDeCqkZ
-hT+RtBGQL2SEdWjxbF43oQopocT8cHvyX6Zaltn0svoGs+wX3Z/H6/8P5anog43U
-65c0A+64Jj00rNDr8j31izhtQMRo892kGeQAaaxg4Pz6HnS7hRC+cOMHUU4HA7iM
-zHrouAdYeTZeZEQOA7SxtCME9ZnGwe2grxPXh/U/80WJGkzLFNcTKdv+rwARAQAB
-tDdEb2NrZXIgUmVsZWFzZSBUb29sIChyZWxlYXNlZG9ja2VyKSA8ZG9ja2VyQGRv
-Y2tlci5jb20+iQIcBBABCgAGBQJWw7vdAAoJEFyzYeVS+w0QHysP/i37m4SyoOCV
-cnybl18vzwBEcp4VCRbXvHvOXty1gccVIV8/aJqNKgBV97lY3vrpOyiIeB8ETQeg
-srxFE7t/Gz0rsLObqfLEHdmn5iBJRkhLfCpzjeOnyB3Z0IJB6UogO/msQVYe5CXJ
-l6uwr0AmoiCBLrVlDAktxVh9RWch0l0KZRX2FpHu8h+uM0/zySqIidlYfLa3y5oH
-scU+nGU1i6ImwDTD3ysZC5jp9aVfvUmcESyAb4vvdcAHR+bXhA/RW8QHeeMFliWw
-7Z2jYHyuHmDnWG2yUrnCqAJTrWV+OfKRIzzJFBs4e88ru5h2ZIXdRepw/+COYj34
-LyzxR2cxr2u/xvxwXCkSMe7F4KZAphD+1ws61FhnUMi/PERMYfTFuvPrCkq4gyBj
-t3fFpZ2NR/fKW87QOeVcn1ivXl9id3MMs9KXJsg7QasT7mCsee2VIFsxrkFQ2jNp
-D+JAERRn9Fj4ArHL5TbwkkFbZZvSi6fr5h2GbCAXIGhIXKnjjorPY/YDX6X8AaHO
-W1zblWy/CFr6VFl963jrjJgag0G6tNtBZLrclZgWhOQpeZZ5Lbvz2ZA5CqRrfAVc
-wPNW1fObFIRtqV6vuVluFOPCMAAnOnqR02w9t17iVQjO3oVN0mbQi9vjuExXh1Yo
-ScVetiO6LSmlQfVEVRTqHLMgXyR/EMo7iQIcBBABCgAGBQJXSWBlAAoJEFyzYeVS
-+w0QeH0QAI6btAfYwYPuAjfRUy9qlnPhZ+xt1rnwsUzsbmo8K3XTNh+l/R08nu0d
-sczw30Q1wju28fh1N8ay223+69f0+yICaXqR18AbGgFGKX7vo0gfEVaxdItUN3eH
-NydGFzmeOKbAlrxIMECnSTG/TkFVYO9Ntlv9vSN2BupmTagTRErxLZKnVsWRzp+X
-elwlgU5BCZ6U6Ze8+bIc6F1bZstf17X8i6XNV/rOCLx2yP0hn1osoljoLPpW8nzk
-wvqYsYbCA28lMt1aqe0UWvRCqR0zxlKn17NZQqjbxcajEMCajoQ01MshmO5GWePV
-iv2abCZ/iaC5zKqVT3deMJHLq7lum6qhA41E9gJH9QoqT+qgadheeFfoC1QP7cke
-+tXmYg2R39p3l5Hmm+JQbP4f9V5mpWExvHGCSbcatr35tnakIJZugq2ogzsm1djC
-Sz9222RXl9OoFqsm1bNzA78+/cOt5N2cyhU0bM2T/zgh42YbDD+JDU/HSmxUIpU+
-wrGvZGM2FU/up0DRxOC4U1fL6HHlj8liNJWfEg3vhougOh66gGF9ik5j4eIlNoz6
-lst+gmvlZQ9/9hRDeoG+AbhZeIlQ4CCw+Y1j/+fUxIzKHPVK+aFJd+oJVNvbojJW
-/SgDdSMtFwqOvXyYcHl30Ws0gZUeDyAmNGZeJ3kFklnApDmeKK+OiQIiBBABCgAM
-BQJXe5zTBYMHhh+AAAoJEDG4FaMBBnSp7YMQAJqrXoBonZAq07B6qUaT3aBCgnY4
-JshbXmFb/XrrS75f7YJDPx2fJJdqrbYDIHHgOjzxvp3ngPpOpJzI5sYmkaugeoCO
-/KHu/+39XqgTB7fguzapRfbvuWp+qzPcHSdb9opnagfzKAze3DQnnLiwCPlsyvGp
-zC4KzXgV2ze/4raaOye1kK7O0cHyapmn/q/TR3S8YapyXq5VpLThwJAw1SRDu0Yx
-eXIAQiIfaSxT79EktoioW2CSV8/djt+gBjXnKYJJA8P1zzX7GNt/Rc2YG0Ot4v6t
-BW16xqFTg+n5JzbeK5cZ1jbIXXfCcaZJyiM2MzYGhSJ9+EV7JYF05OAIWE4SGTRj
-XMquQ2oMLSwMCPQHm+FCD9PXQ0tHYx6tKT34wksdmoWsdejl/n3NS+178mG1WI/l
-N079h3im2gRwOykMou/QWs3vGw/xDoOYHPV2gJ7To9BLVnVK/hROgdFLZFeyRScN
-zwKm57HmYMFA74tX601OiHhk1ymP2UUc25oDWpLXlfcRULJJlo/KfZZF3pmKwIq3
-CilGayFUi1NNwuavG76EcAVtVFUVFFIITwkhkuRbBHIytzEHYosFgD5/acK0Pauq
-JnwrwKv0nWq3aK7nKiALAD+iZvPNjFZau3/APqLEmvmRnAElmugcHsWREFxMMjMM
-VgYFiYKUAJO8u46eiQI4BBMBAgAiBQJVpZ9uAhsvBgsJCAcDAgYVCAIJCgsEFgID
-AQIeAQIXgAAKCRD3YiFXLFJgnbRfEAC9Uai7Rv20QIDlDogRzd+Vebg4ahyoUdj0
-CH+nAk40RIoq6G26u1e+sdgjpCa8jF6vrx+smpgd1HeJdmpahUX0XN3X9f9qU9oj
-9A4I1WDalRWJh+tP5WNv2ySy6AwcP9QnjuBMRTnTK27pk1sEMg9oJHK5p+ts8hlS
-C4SluyMKH5NMVy9c+A9yqq9NF6M6d6/ehKfBFFLG9BX+XLBATvf1ZemGVHQusCQe
-bTGv0C0V9yqtdPdRWVIEhHxyNHATaVYOafTj/EF0lDxLl6zDT6trRV5n9F1VCEh4
-Aal8L5MxVPcIZVO7NHT2EkQgn8CvWjV3oKl2GopZF8V4XdJRl90U/WDv/6cmfI08
-GkzDYBHhS8ULWRFwGKobsSTyIvnbk4NtKdnTGyTJCQ8+6i52s+C54PiNgfj2ieNn
-6oOR7d+bNCcG1CdOYY+ZXVOcsjl73UYvtJrO0Rl/NpYERkZ5d/tzw4jZ6FCXgggA
-/Zxcjk6Y1ZvIm8Mt8wLRFH9Nww+FVsCtaCXJLP8DlJLASMD9rl5QS9Ku3u7ZNrr5
-HWXPHXITX660jglyshch6CWeiUATqjIAzkEQom/kEnOrvJAtkypRJ59vYQOedZ1s
-FVELMXg2UCkD/FwojfnVtjzYaTCeGwFQeqzHmM241iuOmBYPeyTY5veF49aBJA1g
-EJOQTvBR8Q==
-=Yhur
------END PGP PUBLIC KEY BLOCK-----
+# TODO: Remove *-ubuntu-yakkety once 17.07.0-ce hits GA
+SUPPORT_MAP="
+x86_64-centos-7
+x86_64-fedora-24
+x86_64-fedora-25
+x86_64-fedora-26
+x86_64-debian-wheezy
+x86_64-debian-jessie
+x86_64-debian-stretch
+x86_64-ubuntu-trusty
+x86_64-ubuntu-xenial
+x86_64-ubuntu-yakkety
+x86_64-ubuntu-zesty
+s390x-ubuntu-xenial
+s390x-ubuntu-yakkety
+s390x-ubuntu-zesty
+aarch64-ubuntu-xenial
+armv6l-raspbian-jessie
+armv7l-raspbian-jessie
+armv7l-debian-jessie
+armv7l-debian-stretch
+armv7l-ubuntu-trusty
+armv7l-ubuntu-xenial
+armv7l-ubuntu-yakkety
+armv7l-ubuntu-zesty
 "
-
-mirror=''
-while [ $# -gt 0 ]; do
-	case "$1" in
-		--mirror)
-			mirror="$2"
-			shift
-			;;
-		*)
-			echo "Illegal option $1"
-			;;
-	esac
-	shift $(( $# > 0 ? 1 : 0 ))
-done
-
-case "$mirror" in
-	AzureChinaCloud)
-		apt_url="https://mirror.azure.cn/docker-engine/apt"
-		#yum_url="https://mirror.azure.cn/docker-engine/yum"
-		;;
-	Aliyun)
-		apt_url="https://mirrors.aliyun.com/docker-engine/apt"
-		#yum_url="https://mirrors.aliyun.com/docker-engine/yum"
-		;;
-esac
 
 command_exists() {
 	command -v "$@" > /dev/null 2>&1
@@ -221,16 +153,6 @@ semverParse() {
 	patch="${patch%%[-.]*}"
 }
 
-deprecation_notice() {
-	echo
-	echo
-	echo "  WARNING: $1 is no longer updated @ $url"
-	echo "           Installing the legacy docker-engine package..."
-	echo
-	echo
-	sleep 10;
-}
-
 ee_notice() {
 	echo
 	echo
@@ -242,35 +164,6 @@ ee_notice() {
 
 do_install() {
 	echo "Executing docker install script, commit: $SCRIPT_COMMIT_SHA"
-	# TODO: Move this to after we figure out the distribution and the version
-	#       to check whether or not we support that distro-version on that arch
-	architecture=$(uname -m)
-	case $architecture in
-		# officially supported
-		amd64|x86_64)
-			;;
-		# unofficially supported with available repositories
-		armv6l|armv7l)
-			;;
-		# unofficially supported without available repositories
-		aarch64|arm64|ppc64le|s390x)
-			cat 1>&2 <<-EOF
-			Error: This install script does not support $architecture, because no
-			$architecture package exists in Docker's repositories.
-
-			Other install options include checking your distribution's package repository
-			for a version of Docker, or building Docker from source.
-			EOF
-			exit 1
-			;;
-		# not supported
-		*)
-			cat >&2 <<-EOF
-			Error: $architecture is not a recognized platform.
-			EOF
-			exit 1
-			;;
-	esac
 
 	if command_exists docker; then
 		version="$(docker -v | cut -d ' ' -f3 | cut -d ',' -f1)"
@@ -336,30 +229,6 @@ do_install() {
 		fi
 	fi
 
-	curl=''
-	if command_exists curl; then
-		curl='curl -sSL'
-	elif command_exists wget; then
-		curl='wget -qO-'
-	elif command_exists busybox && busybox --list-modules | grep -q wget; then
-		curl='busybox wget -qO-'
-	fi
-
-	#TODO: Remove this once raspian support is added to https://download.docker.com
-	url='https://get.docker.com/'
-	if [ "$CHANNEL" = "test" ]; then
-		url='https://test.docker.com/'
-	fi
-
-	# check to see which repo they are trying to install from
-	if [ -z "$repo" ]; then
-		repo='main'
-		if [ "https://test.docker.com/" = "$url" ]; then
-			repo='testing'
-		fi
-	fi
-	#TODO: Remove to HERE =========================================================
-
 	# perform some very rudimentary platform detection
 	lsb_dist=$( get_distribution )
 	lsb_dist="$(echo "$lsb_dist" | tr '[:upper:]' '[:lower:]')"
@@ -399,14 +268,33 @@ do_install() {
 			fi
 		;;
 
+		rhel|ol|sles)
+			ee_notice "$lsb_dist"
+			exit 1
+			;;
+
 	esac
 
 	# Check if this is a forked Linux distro
 	check_forked
 
+	# Check if we actually support this configuration
+	if ! echo "$SUPPORT_MAP" | grep "$(uname -m)-$lsb_dist-$dist_version" >/dev/null; then
+		cat >&2 <<-'EOF'
+
+		Either your platform is not easily detectable or is not supported by this
+		installer script.
+		Please visit the following URL for more detailed installation instructions:
+
+		https://docs.docker.com/engine/installation/
+
+		EOF
+		exit 1
+	fi
+
 	# Run setup for each distro accordingly
 	case "$lsb_dist" in
-		ubuntu|debian)
+		ubuntu|debian|raspbian)
 			pre_reqs="apt-transport-https ca-certificates curl"
 			if [ "$lsb_dist" = "debian" ] && [ "$dist_version" = "wheezy" ]; then
 				pre_reqs="$pre_reqs python-software-properties"
@@ -425,10 +313,10 @@ do_install() {
 				set -x
 				$sh_c 'apt-get update'
 				$sh_c "apt-get install -y -q $pre_reqs"
-				curl -fsSl "https://download.docker.com/linux/$lsb_dist/gpg" | $sh_c 'apt-key add -'
-				$sh_c "add-apt-repository \"$apt_repo\""
+				curl "https://download.docker.com/linux/$lsb_dist/gpg" | $sh_c 'apt-key add -'
+				$sh_c "echo \"$apt_repo\" > /etc/apt/sources.list.d/docker.list"
 				if [ "$lsb_dist" = "debian" ] && [ "$dist_version" = "wheezy" ]; then
-					$sh_c 'sed -i "/deb-src.*download\.docker/d" /etc/apt/sources.list'
+					$sh_c 'sed -i "/deb-src.*download\.docker/d" /etc/apt/sources.list.d/docker.list'
 				fi
 				$sh_c 'apt-get update'
 				$sh_c 'apt-get install -y -q docker-ce'
@@ -440,7 +328,7 @@ do_install() {
 			yum_repo="https://download.docker.com/linux/$lsb_dist/docker-ce.repo"
 			if [ "$lsb_dist" = "fedora" ]; then
 				if [ "$dist_version" -lt "24" ]; then
-					echo "Error: Only Fedora >=24 are supported by $url"
+					echo "Error: Only Fedora >=24 are supported"
 					exit 1
 				fi
 				pkg_manager="dnf"
@@ -467,101 +355,8 @@ do_install() {
 			echo_docker_as_nonroot
 			exit 0
 			;;
-		raspbian)
-			#TODO: Remove this once raspian support is added to https://download.docker.com
-			deprecation_notice "$lsb_dist"
-			export DEBIAN_FRONTEND=noninteractive
-
-			did_apt_get_update=
-			apt_get_update() {
-				if [ -z "$did_apt_get_update" ]; then
-					( set -x; $sh_c 'sleep 3; apt-get update' )
-					did_apt_get_update=1
-				fi
-			}
-
-			if [ "$lsb_dist" != "raspbian" ]; then
-				# aufs is preferred over devicemapper; try to ensure the driver is available.
-				if ! grep -q aufs /proc/filesystems && ! $sh_c 'modprobe aufs'; then
-					if uname -r | grep -q -- '-generic' && dpkg -l 'linux-image-*-generic' | grep -qE '^ii|^hi' 2>/dev/null; then
-						kern_extras="linux-image-extra-$(uname -r) linux-image-extra-virtual"
-
-						apt_get_update
-						( set -x; $sh_c 'sleep 3; apt-get install -y -q '"$kern_extras" ) || true
-
-						if ! grep -q aufs /proc/filesystems && ! $sh_c 'modprobe aufs'; then
-							echo >&2 'Warning: tried to install '"$kern_extras"' (for AUFS)'
-							echo >&2 ' but we still have no AUFS.  Docker may not work. Proceeding anyways!'
-							( set -x; sleep 10 )
-						fi
-					else
-						echo >&2 'Warning: current kernel is not supported by the linux-image-extra-virtual'
-						echo >&2 ' package.  We have no AUFS support.  Consider installing the packages'
-						echo >&2 ' "linux-image-virtual" and "linux-image-extra-virtual" for AUFS support.'
-						( set -x; sleep 10 )
-					fi
-				fi
-			fi
-
-			# install apparmor utils if they're missing and apparmor is enabled in the kernel
-			# otherwise Docker will fail to start
-			if [ "$(cat /sys/module/apparmor/parameters/enabled 2>/dev/null)" = 'Y' ]; then
-				if command -v apparmor_parser >/dev/null 2>&1; then
-					echo 'apparmor is enabled in the kernel and apparmor utils were already installed'
-				else
-					echo 'apparmor is enabled in the kernel, but apparmor_parser is missing. Trying to install it..'
-					apt_get_update
-					( set -x; $sh_c 'sleep 3; apt-get install -y -q apparmor' )
-				fi
-			fi
-
-			if [ ! -e /usr/lib/apt/methods/https ]; then
-				apt_get_update
-				( set -x; $sh_c 'sleep 3; apt-get install -y -q apt-transport-https ca-certificates' )
-			fi
-			if [ -z "$curl" ]; then
-				apt_get_update
-				( set -x; $sh_c 'sleep 3; apt-get install -y -q curl ca-certificates' )
-				curl='curl -sSL'
-			fi
-			if ! command -v gpg > /dev/null; then
-				apt_get_update
-				( set -x; $sh_c 'sleep 3; apt-get install -y -q gnupg2 || apt-get install -y -q gnupg' )
-			fi
-
-			# dirmngr is a separate package in ubuntu yakkety; see https://bugs.launchpad.net/ubuntu/+source/apt/+bug/1634464
-			if ! command -v dirmngr > /dev/null; then
-				apt_get_update
-				( set -x; $sh_c 'sleep 3; apt-get install -y -q dirmngr' )
-			fi
-
-			(
-			set -x
-			echo "$docker_key" | $sh_c 'apt-key add -'
-			$sh_c "mkdir -p /etc/apt/sources.list.d"
-			$sh_c "echo deb \[arch=$(dpkg --print-architecture)\] ${apt_url}/repo ${lsb_dist}-${dist_version} ${repo} > /etc/apt/sources.list.d/docker.list"
-			$sh_c 'sleep 3; apt-get update; apt-get install -y -q docker-engine'
-			)
-			echo_docker_as_nonroot
-			exit 0
-			;;
-
-		rhel|ol|sles)
-			ee_notice "$lsb_dist"
-			exit 1
-			;;
 	esac
 
-	# intentionally mixed spaces and tabs here -- tabs are stripped by "<<-'EOF'", spaces are kept in the output
-	cat >&2 <<-'EOF'
-
-	Either your platform is not easily detectable or is not supported by this
-	installer script.
-	Please visit the following URL for more detailed installation instructions:
-
-	https://docs.docker.com/engine/installation/
-
-	EOF
 	exit 1
 }
 


### PR DESCRIPTION
## Major Notes:

* Removes old raspbian cruft now that raspbian has a repo on
download.docker.com
* Adds a support matrix so that we can have an easier time updating
what architectures/distros we support
* Added support for s390x and aarch64
* Had to change add-apt-repository to an echo into a file, was not
functioning correctly on raspbian see moby/moby#31405
* Update testing pipeline for multiarch
* Removed deprecation warnings for raspbian

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>