### PR TITLE
Update verification targets to include arch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,15 +1,15 @@
 #!groovy
 
 def verifyTargets = [
-  'verify-install-centos-7',
-  'verify-install-fedora-24',
-  'verify-install-fedora-25',
-  'verify-install-debian-wheezy',
-  'verify-install-debian-jessie',
-  'verify-install-debian-stretch',
-  'verify-install-ubuntu-trusty',
-  'verify-install-ubuntu-xenial',
-  'verify-install-ubuntu-zesty',
+  'x86_64-verify-install-centos-7',
+  'x86_64-verify-install-fedora-24',
+  'x86_64-verify-install-fedora-25',
+  'x86_64-verify-install-debian-wheezy',
+  'x86_64-verify-install-debian-jessie',
+  'x86_64-verify-install-debian-stretch',
+  'x86_64-verify-install-ubuntu-trusty',
+  'x86_64-verify-install-ubuntu-xenial',
+  'x86_64-verify-install-ubuntu-zesty',
 ]
 
 def armhfverifyTargets = [
@@ -40,7 +40,7 @@ def genVerifyJob(String t, String label) {
             channel='edge'
         }
         sh("make CHANNEL_TO_TEST=${channel} clean ${t}")
-        archiveArtifacts 'verify-install-*'
+        archiveArtifacts '*-verify-install-*'
       }
     }
   } ]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL:=/bin/bash
 DISTROS:=centos-7 fedora-24 fedora-25 debian-wheezy debian-jessie debian-stretch ubuntu-trusty ubuntu-xenial ubuntu-yakkety ubuntu-zesty
-VERIFY_INSTALL_DISTROS:=$(addprefix verify-install-,$(DISTROS))
+VERIFY_INSTALL_DISTROS:=$(addprefix x86_64-verify-install-,$(DISTROS))
 CHANNEL_TO_TEST?=test
 SHELLCHECK=shellcheck
 
@@ -13,9 +13,10 @@ check: $(VERIFY_INSTALL_DISTROS)
 
 .PHONY: clean
 clean:
-	$(RM) verify-install-*
+	$(RM) *-verify-install-*
+	$(RM) -r build
 
-verify-install-%:
+x86_64-verify-install-%:
 	mkdir -p build
 	sed 's/DEFAULT_CHANNEL_VALUE="test"/DEFAULT_CHANNEL_VALUE="$(CHANNEL_TO_TEST)"/' install.sh > build/install.sh
 	set -o pipefail && docker run \


### PR DESCRIPTION
Ran into an issue with the jenkins build with archiving artifacts. Chose
to remedy this by naming all of the potential artifacts with the same
pattern

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>