### PR TITLE
Use mirror provided by AzureChinaCloud

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -75,6 +75,9 @@ case "$mirror" in
 	Aliyun)
 		DOWNLOAD_URL="https://mirrors.aliyun.com/docker-ce"
 		;;
+	AzureChinaCloud)
+		DOWNLOAD_URL="https://mirror.azure.cn/docker-ce"
+		;;
 esac
 
 command_exists() {


### PR DESCRIPTION
In order to install docker engine on Ubuntu from China mirror provided by AzureChinaCloud  if mirror option is present.

usage:
sh install --mirror AzureChinaCloud

Without this change, the docker install will always fail on downloading from global site due to network issue.