### PR TITLE
Adds support for raspbian stretch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,8 @@ def armhfverifyTargets = [
   'armhf-verify-install-raspbian-stretch',
   'armhf-verify-install-debian-jessie',
   'armhf-verify-install-debian-stretch',
-  'armhf-verify-install-ubuntu-trusty',
+  // TEMPORARY: security.ubuntu.com is returning a 404 for trusty armhf, support may have ended
+  // 'armhf-verify-install-ubuntu-trusty',
   'armhf-verify-install-ubuntu-xenial',
   'armhf-verify-install-ubuntu-zesty',
 ]
@@ -45,6 +46,13 @@ def genVerifyJob(String t, String label) {
       }
     }
   } ]
+}
+
+wrappedNode(label: 'aufs', cleanWorkspace: true) {
+  stage('Shellcheck') {
+    checkout scm
+    sh('make shellcheck')
+  }
 }
 
 def verifyJobs = [:]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,6 +14,7 @@ def verifyTargets = [
 
 def armhfverifyTargets = [
   'armhf-verify-install-raspbian-jessie',
+  'armhf-verify-install-raspbian-stretch',
   'armhf-verify-install-debian-jessie',
   'armhf-verify-install-debian-stretch',
   'armhf-verify-install-ubuntu-trusty',

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@ SHELL:=/bin/bash
 DISTROS:=centos-7 fedora-24 fedora-25 debian-wheezy debian-jessie debian-stretch ubuntu-trusty ubuntu-xenial ubuntu-yakkety ubuntu-zesty
 VERIFY_INSTALL_DISTROS:=$(addprefix x86_64-verify-install-,$(DISTROS))
 CHANNEL_TO_TEST?=test
-SHELLCHECK=shellcheck
+SHELLCHECK_EXCLUSIONS=$(addprefix -e, SC1091 SC1117)
+SHELLCHECK=docker run --rm -v "$(CURDIR)":/v -w /v koalaman/shellcheck $(SHELLCHECK_EXCLUSIONS)
 
 .PHONY: shellcheck
 shellcheck:

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,16 @@ armhf-verify-install-raspbian-jessie:
 		resin/rpi-raspbian:jessie \
 		/v/verify-docker-install | tee $@
 
+armhf-verify-install-raspbian-stretch:
+	mkdir -p build
+	sed 's/DEFAULT_CHANNEL_VALUE="test"/DEFAULT_CHANNEL_VALUE="$(CHANNEL_TO_TEST)"/' install.sh > build/install.sh
+	set -o pipefail && docker run \
+		--rm \
+		-v $(CURDIR):/v \
+		-w /v \
+		resin/rpi-raspbian:stretch \
+		/v/verify-docker-install | tee $@
+
 armhf-verify-install-%:
 	mkdir -p build
 	sed 's/DEFAULT_CHANNEL_VALUE="test"/DEFAULT_CHANNEL_VALUE="$(CHANNEL_TO_TEST)"/' install.sh > build/install.sh

--- a/install.sh
+++ b/install.sh
@@ -49,6 +49,8 @@ s390x-ubuntu-zesty
 aarch64-ubuntu-xenial
 armv6l-raspbian-jessie
 armv7l-raspbian-jessie
+armv6l-raspbian-stretch
+armv7l-raspbian-stretch
 armv7l-debian-jessie
 armv7l-debian-stretch
 armv7l-ubuntu-trusty
@@ -505,7 +507,9 @@ do_install() {
 				apt_get_update
 				( set -x; $sh_c 'sleep 3; apt-get install -y -q dirmngr' )
 			fi
-
+			if [ "$dist_version" = "stretch" ]; then
+				dist_version="jessie"
+			fi
 			(
 			set -x
 			echo "$docker_key" | $sh_c 'apt-key add -'


### PR DESCRIPTION
## Overview

Basically uses the jessie repo for raspbian stretch due to raspbian
jessie download links being taken off the official raspbian site.

## NOTE
This is only a temporary fix and should not be considered permanent


Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>

ping @StefanScherer @alexellis