### PR TITLE
Fedora 24 deprecation notice, reached EOL, adds Fedora 26

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,8 +2,8 @@
 
 def verifyTargets = [
   'x86_64-verify-install-centos-7',
-  'x86_64-verify-install-fedora-24',
   'x86_64-verify-install-fedora-25',
+  'x86_64-verify-install-fedora-26',
   'x86_64-verify-install-debian-wheezy',
   'x86_64-verify-install-debian-jessie',
   'x86_64-verify-install-debian-stretch',

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHELL:=/bin/bash
-DISTROS:=centos-7 fedora-24 fedora-25 debian-wheezy debian-jessie debian-stretch ubuntu-trusty ubuntu-xenial ubuntu-yakkety ubuntu-zesty
+DISTROS:=centos-7 fedora-25 fedora-26 debian-wheezy debian-jessie debian-stretch ubuntu-trusty ubuntu-xenial ubuntu-yakkety ubuntu-zesty
 VERIFY_INSTALL_DISTROS:=$(addprefix x86_64-verify-install-,$(DISTROS))
 CHANNEL_TO_TEST?=test
 SHELLCHECK_EXCLUSIONS=$(addprefix -e, SC1091 SC1117)

--- a/install.sh
+++ b/install.sh
@@ -417,6 +417,13 @@ do_install() {
 		centos|fedora)
 			yum_repo="$DOWNLOAD_URL/linux/$lsb_dist/docker-ce.repo"
 			if [ "$lsb_dist" = "fedora" ]; then
+				if [ "$dist_version" = "24" ]; then
+					echo
+					echo "Warning: Fedora 24 has reached EOL"
+					echo "         Support for Fedora 24 for this installation script will be removed on October 1, 2017"
+					echo
+					sleep 10
+				fi
 				if [ "$dist_version" -lt "24" ]; then
 					echo "Error: Only Fedora >=24 are supported"
 					exit 1


### PR DESCRIPTION
Fedora 24 has reached EOL on August 8, 2017 https://fedoramagazine.org/fedora-24-eol/