### PR TITLE
Fixed install.sh for Centos7 with lsb_release command available

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -349,6 +349,12 @@ do_install() {
 			esac
 		;;
 
+		centos)
+			if [ -z "$dist_version" ] && [ -r /etc/os-release ]; then
+				dist_version="$(. /etc/os-release && echo "$VERSION_ID")"
+			fi
+		;;
+
 		*)
 			if command_exists lsb_release; then
 				dist_version="$(lsb_release --codename | cut -f2)"


### PR DESCRIPTION
Background:
  On Centos 7, when command lsb_release available, the dist_version evaluated to 'Core'
  To be in line with the content of $SUPPORT_MAP, a '7' was needed.
  The script failed

Solution:
  Added case centos to the case environment on "$lsb_dist"
  Now the dist_version is evaluated to '7'
  The script runs as expected