### PR TITLE
Removes temporary redirect for artful repositories

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,11 +22,13 @@ def armhfverifyTargets = [
   // 'armhf-verify-install-ubuntu-trusty',
   'armhf-verify-install-ubuntu-xenial',
   'armhf-verify-install-ubuntu-zesty',
+  'armhf-verify-install-ubuntu-artful',
 ]
 
 def s390xverifyTargets = [
   's390x-verify-install-ubuntu-xenial',
   's390x-verify-install-ubuntu-zesty',
+  's390x-verify-install-ubuntu-artful',
 ]
 
 def aarch64verifyTargets = [
@@ -36,6 +38,7 @@ def aarch64verifyTargets = [
 def ppc64leverifyTargets = [
   'ppc64le-verify-install-ubuntu-xenial',
   'ppc64le-verify-install-ubuntu-zesty',
+  'ppc64le-verify-install-ubuntu-artful',
 ]
 
 def genVerifyJob(String t, String label) {

--- a/install.sh
+++ b/install.sh
@@ -356,13 +356,6 @@ do_install() {
 			else
 				pre_reqs="$pre_reqs software-properties-common"
 			fi
-
-			# TODO: DELETE HERE
-			if [ "$lsb_dist" = "ubuntu" ] && [ "$dist_version" = "artful" ]; then
-				dist_version="zesty"
-			fi
-			# TODO: DELETE HERE
-
 			if ! command -v gpg > /dev/null; then
 				pre_reqs="$pre_reqs gnupg"
 			fi


### PR DESCRIPTION
Artful repositories for download.docker.com just went live for the test
channel, this should make the redirect unneccessary.

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>