### PR TITLE
Add debian buster to install script

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,6 +7,7 @@ def verifyTargets = [
   'x86_64-verify-install-debian-wheezy',
   'x86_64-verify-install-debian-jessie',
   'x86_64-verify-install-debian-stretch',
+  'x86_64-verify-install-debian-buster',
   'x86_64-verify-install-ubuntu-trusty',
   'x86_64-verify-install-ubuntu-xenial',
   'x86_64-verify-install-ubuntu-zesty',
@@ -18,6 +19,7 @@ def armhfverifyTargets = [
   'armhf-verify-install-raspbian-stretch',
   'armhf-verify-install-debian-jessie',
   'armhf-verify-install-debian-stretch',
+  'armhf-verify-install-debian-buster',
   // TEMPORARY: security.ubuntu.com is returning a 404 for trusty armhf, support may have ended
   // 'armhf-verify-install-ubuntu-trusty',
   'armhf-verify-install-ubuntu-xenial',

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHELL:=/bin/bash
-DISTROS:=centos-7 fedora-25 fedora-26 debian-wheezy debian-jessie debian-stretch ubuntu-trusty ubuntu-xenial ubuntu-yakkety ubuntu-zesty ubuntu-artful
+DISTROS:=centos-7 fedora-25 fedora-26 debian-wheezy debian-jessie debian-stretch debian-buster ubuntu-trusty ubuntu-xenial ubuntu-yakkety ubuntu-zesty ubuntu-artful
 VERIFY_INSTALL_DISTROS:=$(addprefix x86_64-verify-install-,$(DISTROS))
 CHANNEL_TO_TEST?=test
 SHELLCHECK_EXCLUSIONS=$(addprefix -e, SC1091 SC1117)

--- a/install.sh
+++ b/install.sh
@@ -38,6 +38,7 @@ x86_64-fedora-26
 x86_64-debian-wheezy
 x86_64-debian-jessie
 x86_64-debian-stretch
+x86_64-debian-buster
 x86_64-ubuntu-trusty
 x86_64-ubuntu-xenial
 x86_64-ubuntu-zesty
@@ -55,6 +56,7 @@ armv6l-raspbian-stretch
 armv7l-raspbian-stretch
 armv7l-debian-jessie
 armv7l-debian-stretch
+armv7l-debian-buster
 armv7l-ubuntu-trusty
 armv7l-ubuntu-xenial
 armv7l-ubuntu-zesty


### PR DESCRIPTION
Debian Buster builds for Docker CE are now available on the test channel.

This PR adds:
* Support in the install script
* Support in the Makefile checks
* Support in the `Jenkinsfile`

Relates to: https://github.com/docker/for-linux/issues/102