### PR TITLE
Adds temporary support for Fedora 27

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,6 +4,7 @@ def verifyTargets = [
   'x86_64-verify-install-centos-7',
   'x86_64-verify-install-fedora-25',
   'x86_64-verify-install-fedora-26',
+  'x86_64-verify-install-fedora-27',
   'x86_64-verify-install-debian-wheezy',
   'x86_64-verify-install-debian-jessie',
   'x86_64-verify-install-debian-stretch',

--- a/install.sh
+++ b/install.sh
@@ -35,6 +35,7 @@ x86_64-centos-7
 x86_64-fedora-24
 x86_64-fedora-25
 x86_64-fedora-26
+x86_64-fedora-27
 x86_64-debian-wheezy
 x86_64-debian-jessie
 x86_64-debian-stretch
@@ -407,6 +408,13 @@ do_install() {
 				fi
 				$sh_c "$pkg_manager install -y -q $pre_reqs"
 				$sh_c "$config_manager --add-repo $yum_repo"
+
+				# DELETE FROM HERE
+				if [ "$dist_version" -eq "27" ]; then
+					$sh_c "sed -i 's/\\\$releasever/26/g' /etc/yum.repos.d/docker-ce.repo"
+				fi
+				# DELETE TO HERE
+
 				if [ "$CHANNEL" != "stable" ]; then
 					$sh_c "$config_manager $enable_channel_flag docker-ce-$CHANNEL"
 				fi

--- a/install.sh
+++ b/install.sh
@@ -412,6 +412,17 @@ do_install() {
 				# DELETE FROM HERE
 				if [ "$dist_version" -eq "27" ]; then
 					$sh_c "sed -i 's/\\\$releasever/26/g' /etc/yum.repos.d/docker-ce.repo"
+					set +x
+					echo "=================================================================================="
+					echo
+					echo "WARNING: Hardcoding repository to use Fedora 26 repositories"
+					echo "         You will need to update your repositories after the release of 17.12.0-ce"
+					echo
+					echo "         See: https://github.com/docker/for-linux/issues/164#issuecomment-345034887"
+					echo
+					echo "=================================================================================="
+					sleep 10
+					set -x
 				fi
 				# DELETE TO HERE
 


### PR DESCRIPTION
This fix is to remedy users who are experiencing issues with Fedora 27,
released on November 15, 2017.

Once we have repositories up for Fedora 27 the designated lines should
be deleted to allow for use of the proper repositories

Relates to: https://github.com/docker/for-linux/issues/164

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>