### PR TITLE
Add new aarch64 distros

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,6 +36,9 @@ def s390xverifyTargets = [
 
 def aarch64verifyTargets = [
   'aarch64-verify-install-ubuntu-xenial',
+  'aarch64-verify-install-ubuntu-zesty',
+  'aarch64-verify-install-debian-jessie',
+  'aarch64-verify-install-debian-stretch',
 ]
 
 def ppc64leverifyTargets = [


### PR DESCRIPTION
Adds the following distros (aarch64):
* Ubuntu Zesty
* Debian Jessie
* Debian Stretch

Debian Jessie for aarch64 needs backport repos since libseccomp2 does
not exist on the main aarch64 repos.

Should coincide with the release of `17.12.0-ce`

CI will most likely fail until the release of `17.12.0-ce-rc4`

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>