### PR TITLE
Remove Fedora 24 support

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -32,7 +32,6 @@ DOWNLOAD_URL="https://download.docker.com"
 
 SUPPORT_MAP="
 x86_64-centos-7
-x86_64-fedora-24
 x86_64-fedora-25
 x86_64-fedora-26
 x86_64-fedora-27
@@ -394,14 +393,7 @@ do_install() {
 		centos|fedora)
 			yum_repo="$DOWNLOAD_URL/linux/$lsb_dist/docker-ce.repo"
 			if [ "$lsb_dist" = "fedora" ]; then
-				if [ "$dist_version" = "24" ]; then
-					echo
-					echo "Warning: Fedora 24 has reached EOL"
-					echo "         Support for Fedora 24 for this installation script will be removed on October 1, 2017"
-					echo
-					sleep 10
-				fi
-				if [ "$dist_version" -lt "24" ]; then
+				if [ "$dist_version" -lt "25" ]; then
 					echo "Error: Only Fedora >=24 are supported"
 					exit 1
 				fi


### PR DESCRIPTION
Support was supposed to be removed a while ago.

Fedora 24 EOL on [August 8, 2017](https://fedoramagazine.org/fedora-24-eol/)

Signed-off-by: Eli Uriegas <seemethere101@gmail.com>