### PR TITLE
Detect OSMC and install the correct package.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -180,8 +180,13 @@ check_forked() {
 			EOF
 		else
 			if [ -r /etc/debian_version ] && [ "$lsb_dist" != "ubuntu" ] && [ "$lsb_dist" != "raspbian" ]; then
-				# We're Debian and don't even know it!
-				lsb_dist=debian
+				if [ "$lsb_dist" = "osmc" ]; then
+					# OSMC runs Raspbian
+					lsb_dist=raspbian
+				else
+					# We're Debian and don't even know it!
+					lsb_dist=debian
+				fi
 				dist_version="$(sed 's/\/.*//' /etc/debian_version | sed 's/\..*//')"
 				case "$dist_version" in
 					9)


### PR DESCRIPTION
`lsb_release` in OSMC returns `osmc`, causing the install script to incorrectly assume that it is running stock Debian. This causes `"$(uname -m)-$lsb_dist-$dist_version"` to return `armv6l-debian-jessie` instead of the correct value `armv6l-raspbian-jessie`.

This pull request adds a special test for this case and ensures the correct distribution is set.