### PR TITLE
Add Parrot support

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -189,7 +189,7 @@ check_forked() {
 				fi
 				dist_version="$(sed 's/\/.*//' /etc/debian_version | sed 's/\..*//')"
 				case "$dist_version" in
-					9)
+					9|'Parrot')
 						dist_version="stretch"
 					;;
 					8|'Kali Linux 2')


### PR DESCRIPTION
even if the latest versions of Parrot OS are based on Debian buster, to consider Parrot as based on Stretch is completely safe in this script, and it works on all the computers we tested it on.