### PR TITLE
Adds new rpm based aarch64 distros

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,6 +35,9 @@ def aarch64verifyTargets = [
   'aarch64-verify-install-ubuntu-xenial',
   'aarch64-verify-install-debian-jessie',
   'aarch64-verify-install-debian-stretch',
+  'aarch64-verify-install-centos-7',
+  'aarch64-verify-install-fedora-26',
+  'aarch64-verify-install-fedora-27',
 ]
 
 def ppc64leverifyTargets = [

--- a/install.sh
+++ b/install.sh
@@ -53,6 +53,9 @@ aarch64-ubuntu-xenial
 aarch64-ubuntu-zesty
 aarch64-debian-jessie
 aarch64-debian-stretch
+aarch64-fedora-26
+aarch64-fedora-27
+aarch64-centos-7
 armv6l-raspbian-jessie
 armv7l-raspbian-jessie
 armv6l-raspbian-stretch


### PR DESCRIPTION
Based off new distributions added in https://github.com/docker/docker-ce-packaging/pull/71

Should add support for `aarch64` for:
* Fedora 26
* Fedora 27
* Centos 7

DO NOT MERGE UNTIL THE RELEASE OF `18.02.0-ce-rc1`
Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>