### PR TITLE
Removes Ubuntu Zesty from testing pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,6 @@ def verifyTargets = [
   'x86_64-verify-install-debian-buster',
   'x86_64-verify-install-ubuntu-trusty',
   'x86_64-verify-install-ubuntu-xenial',
-  'x86_64-verify-install-ubuntu-zesty',
   'x86_64-verify-install-ubuntu-artful',
 ]
 
@@ -24,26 +23,22 @@ def armhfverifyTargets = [
   // TEMPORARY: security.ubuntu.com is returning a 404 for trusty armhf, support may have ended
   // 'armhf-verify-install-ubuntu-trusty',
   'armhf-verify-install-ubuntu-xenial',
-  'armhf-verify-install-ubuntu-zesty',
   'armhf-verify-install-ubuntu-artful',
 ]
 
 def s390xverifyTargets = [
   's390x-verify-install-ubuntu-xenial',
-  's390x-verify-install-ubuntu-zesty',
   's390x-verify-install-ubuntu-artful',
 ]
 
 def aarch64verifyTargets = [
   'aarch64-verify-install-ubuntu-xenial',
-  'aarch64-verify-install-ubuntu-zesty',
   'aarch64-verify-install-debian-jessie',
   'aarch64-verify-install-debian-stretch',
 ]
 
 def ppc64leverifyTargets = [
   'ppc64le-verify-install-ubuntu-xenial',
-  'ppc64le-verify-install-ubuntu-zesty',
   'ppc64le-verify-install-ubuntu-artful',
 ]
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHELL:=/bin/bash
-DISTROS:=centos-7 fedora-25 fedora-26 debian-wheezy debian-jessie debian-stretch debian-buster ubuntu-trusty ubuntu-xenial ubuntu-yakkety ubuntu-zesty ubuntu-artful
+DISTROS:=centos-7 fedora-25 fedora-26 debian-wheezy debian-jessie debian-stretch debian-buster ubuntu-trusty ubuntu-xenial ubuntu-yakkety ubuntu-artful
 VERIFY_INSTALL_DISTROS:=$(addprefix x86_64-verify-install-,$(DISTROS))
 CHANNEL_TO_TEST?=test
 SHELLCHECK_EXCLUSIONS=$(addprefix -e, SC1091 SC1117)


### PR DESCRIPTION
Ubuntu Zesty repositories have moved and the official docker images do not contain the correct repositories

CI Failures looked like:
```
W: The repository 'http://archive.ubuntu.com/ubuntu zesty Release' does not have a Release file.
W: The repository 'http://archive.ubuntu.com/ubuntu zesty-updates Release' does not have a Release file.
W: The repository 'http://archive.ubuntu.com/ubuntu zesty-backports Release' does not have a Release file.
W: The repository 'http://security.ubuntu.com/ubuntu zesty-security Release' does not have a Release file.
E: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/zesty/universe/source/Sources  404  Not Found [IP: 91.189.88.161 80]
E: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/zesty-updates/universe/source/Sources  404  Not Found [IP: 91.189.88.161 80]
E: Failed to fetch http://archive.ubuntu.com/ubuntu/dists/zesty-backports/multiverse/binary-amd64/Packages  404  Not Found [IP: 91.189.88.161 80]
E: Failed to fetch http://security.ubuntu.com/ubuntu/dists/zesty-security/universe/source/Sources  404  Not Found [IP: 91.189.91.26 80]
E: Some index files failed to download. They have been ignored, or old ones used instead.
Makefile:21: recipe for target 'x86_64-verify-install-ubuntu-zesty' failed
make: *** [x86_64-verify-install-ubuntu-zesty] Error 100
```

In the future we may want to remove zesty support altogether, probably when the latest edge release no longer supports zesty

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>