### PR TITLE
relax the regex to match packages easier

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -415,7 +415,7 @@ do_install() {
 					echo "# WARNING: VERSION pinning is not supported in DRY_RUN"
 				else
 					# Will work for incomplete versions IE (17.12), but may not actually grab the "latest" if in the test channel
-					pkg_pattern="$(echo "$VERSION" | sed "s/-ce-/~ce~/g" | sed "s/-/.*/g").*-0~$lsb_dist"
+					pkg_pattern="$(echo "$VERSION" | sed "s/-ce-/~ce~.*/g" | sed "s/-/.*/g").*-0~$lsb_dist"
 					search_command="apt-cache madison 'docker-ce' | grep '$pkg_pattern' | head -1 | cut -d' ' -f 4"
 					pkg_version="$($sh_c "$search_command")"
 					echo "INFO: Searching repository for VERSION '$VERSION'"
@@ -475,7 +475,7 @@ do_install() {
 				if is_dry_run; then
 					echo "# WARNING: VERSION pinning is not supported in DRY_RUN"
 				else
-					pkg_pattern="$(echo "$VERSION" | sed "s/-ce-/\\\\.ce\\\\./g" | sed "s/-/.*/g").*$pkg_suffix"
+					pkg_pattern="$(echo "$VERSION" | sed "s/-ce-/\\\\.ce.*/g" | sed "s/-/.*/g").*$pkg_suffix"
 					search_command="$pkg_manager list --showduplicates 'docker-ce' | grep '$pkg_pattern' | tail -1 | awk '{print \$2}'"
 					pkg_version="$($sh_c "$search_command")"
 					echo "INFO: Searching repository for VERSION '$VERSION'"


### PR DESCRIPTION
This is needed to allow package install of specific versions because of upcoming package name format change.

Without this PR, there would not be a match for deb packages:
```
apt-cache madison 'docker-ce' | grep '18.04.0~ce~beta1.*-0~ubuntu' | head -1 | cut -d' ' -f 4
```

With this PR, will be able to match deb packages:
```
apt-cache madison 'docker-ce' | grep '18.04.0~ce~.*beta1.*-0~ubuntu' | head -1 | cut -d' ' -f 4
18.04.0~ce~1.1.beta1-0~ubuntu
```

Similarly without this PR for rpm packages:

```
yum list --showduplicates 'docker-ce' | grep '18.04.0\.ce\.beta1.*el' | tail -1 | awk '{print $2}'
```

And with this PR, able to match rpm packages:
```
yum list --showduplicates 'docker-ce' | grep '18.04.0\.ce.*beta1.*el' | tail -1 | awk '{print $2}'
18.04.0.ce-1.1.beta1.el7.centos
```