### PR TITLE
Set to explictly disable all repos for RPM first

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -423,7 +423,7 @@ do_install() {
 				$sh_c 'apt-get update -qq >/dev/null'
 			)
 			pkg_version=""
-			if [ ! -z "$VERSION" ]; then
+			if [ -n "$VERSION" ]; then
 				if is_dry_run; then
 					echo "# WARNING: VERSION pinning is not supported in DRY_RUN"
 				else
@@ -491,7 +491,7 @@ do_install() {
 				$sh_c "$pkg_manager makecache"
 			)
 			pkg_version=""
-			if [ ! -z "$VERSION" ]; then
+			if [ -n "$VERSION" ]; then
 				if is_dry_run; then
 					echo "# WARNING: VERSION pinning is not supported in DRY_RUN"
 				else

--- a/install.sh
+++ b/install.sh
@@ -466,12 +466,14 @@ do_install() {
 				pkg_manager="dnf"
 				config_manager="dnf config-manager"
 				enable_channel_flag="--set-enabled"
+				disable_channel_flag="--set-disabled"
 				pre_reqs="dnf-plugins-core"
 				pkg_suffix="fc$dist_version"
 			else
 				pkg_manager="yum"
 				config_manager="yum-config-manager"
 				enable_channel_flag="--enable"
+				disable_channel_flag="--disable"
 				pre_reqs="yum-utils"
 				pkg_suffix="el"
 			fi
@@ -483,6 +485,7 @@ do_install() {
 				$sh_c "$config_manager --add-repo $yum_repo"
 
 				if [ "$CHANNEL" != "stable" ]; then
+					$sh_c "$config_manager $disable_channel_flag docker-ce-*"
 					$sh_c "$config_manager $enable_channel_flag docker-ce-$CHANNEL"
 				fi
 				$sh_c "$pkg_manager makecache"


### PR DESCRIPTION
Makes it so that the repo that's enabled is only the channel that we
specify.

Was the case where it'd automatically enable stable without explicitly
asking if we want stable enabled.

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>