### PR TITLE
Add Fedora 29, and remove Fedora < 28

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,8 +2,8 @@
 
 def verifyTargets = [
   'x86_64-verify-install-centos-7',
-  'x86_64-verify-install-fedora-26',
-  'x86_64-verify-install-fedora-27',
+  'x86_64-verify-install-fedora-28',
+  'x86_64-verify-install-fedora-29',
   'x86_64-verify-install-debian-jessie',
   'x86_64-verify-install-debian-stretch',
   'x86_64-verify-install-debian-buster',
@@ -31,8 +31,8 @@ def aarch64verifyTargets = [
   'aarch64-verify-install-debian-jessie',
   'aarch64-verify-install-debian-stretch',
   'aarch64-verify-install-centos-7',
-  'aarch64-verify-install-fedora-26',
-  'aarch64-verify-install-fedora-27',
+  'aarch64-verify-install-fedora-28',
+  'aarch64-verify-install-fedora-29',
 ]
 
 def ppc64leverifyTargets = [

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHELL:=/bin/bash
-DISTROS:=centos-7 fedora-26 fedora-27 debian-wheezy debian-jessie debian-stretch debian-buster ubuntu-trusty ubuntu-xenial ubuntu-yakkety
+DISTROS:=centos-7 fedora-28 fedora-29 debian-jessie debian-stretch debian-buster ubuntu-trusty ubuntu-xenial ubuntu-yakkety ubuntu-artful
 VERIFY_INSTALL_DISTROS:=$(addprefix x86_64-verify-install-,$(DISTROS))
 CHANNEL_TO_TEST?=test
 VERSION?=

--- a/install.sh
+++ b/install.sh
@@ -40,9 +40,8 @@ fi
 
 SUPPORT_MAP="
 x86_64-centos-7
-x86_64-fedora-26
-x86_64-fedora-27
 x86_64-fedora-28
+x86_64-fedora-29
 x86_64-debian-jessie
 x86_64-debian-stretch
 x86_64-debian-buster
@@ -58,9 +57,8 @@ aarch64-ubuntu-bionic
 aarch64-debian-jessie
 aarch64-debian-stretch
 aarch64-debian-buster
-aarch64-fedora-26
-aarch64-fedora-27
 aarch64-fedora-28
+aarch64-fedora-29
 aarch64-centos-7
 armv6l-raspbian-jessie
 armv7l-raspbian-jessie
@@ -435,8 +433,8 @@ do_install() {
 				exit 1
 			fi
 			if [ "$lsb_dist" = "fedora" ]; then
-				if [ "$dist_version" -lt "26" ]; then
-					echo "Error: Only Fedora >=26 are supported"
+				if [ "$dist_version" -lt "28" ]; then
+					echo "Error: Only Fedora >=28 is supported"
 					exit 1
 				fi
 


### PR DESCRIPTION
Relates to:

- https://github.com/docker/docker-ce-packaging/pull/212 Add initial scripts for Fedora 29
- https://github.com/docker/docker-ce-packaging/pull/256 [18.09 backport] Add initial scripts for Fedora 29
- https://github.com/docker/for-linux/issues/430 Please provide repo for docker-ce on Fedora 29
