### PR TITLE
Use "stable" as default channel

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -19,11 +19,12 @@ set -e
 SCRIPT_COMMIT_SHA=UNKNOWN
 
 
-# This value will automatically get changed for:
-#   * edge
+# The channel to install from:
+#   * nightly
 #   * test
-#   * experimental
-DEFAULT_CHANNEL_VALUE="test"
+#   * stable
+#   * edge (deprecated)
+DEFAULT_CHANNEL_VALUE="stable"
 if [ -z "$CHANNEL" ]; then
 	CHANNEL=$DEFAULT_CHANNEL_VALUE
 fi


### PR DESCRIPTION
Looks like "this value will automatically get changed" may
not be correct, as installing with this script enabled the
"edge" channel.


```
DRY_RUN=1 ./install.sh 
# Executing docker install script, commit: 40b1b76
...

yum install -y -q yum-utils
yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
yum-config-manager --disable docker-ce-*
yum-config-manager --enable docker-ce-edge
yum makecache
yum install -y -q docker-ce
```

fixes https://github.com/docker/docker-install/issues/77