### PR TITLE
Add an error message when the distribution is not supported

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -442,6 +442,12 @@ do_install() {
 			echo_docker_as_nonroot
 			exit 0
 			;;
+		*)
+			echo
+			echo "ERROR: Unsupported distribution '$lsb_dist'"
+			echo
+			exit 1
+			;;
 	esac
 	exit 1
 }


### PR DESCRIPTION
Adds an error message if the distribution is not supported by
this script.  Previously the script would exit without a message
which didn't give much hints as to the problem.

Signed-off-by: Russell Cardullo <russellcardullo@gmail.com>