### PR TITLE
19.03 rootless install

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ From the source repo (This will install latest from the `test` channel):
 sh install.sh
 ```
 
+For rootless installation, multiple channels are present for the user to install.
+By default, it installs from the `test` channel
+```shell
+  sh rootless-install.sh test
+  sh rootless-install.sh nightly
+  sh rootless-install.sh stable
+```
+
 ## Testing:
 
 To verify that the install script works amongst the supported operating systems run:

--- a/rootless-install.sh
+++ b/rootless-install.sh
@@ -25,8 +25,6 @@ init_vars() {
 	if systemctl --user daemon-reload >/dev/null 2>&1; then
 		SYSTEMD=1
 	fi
-
-	## Add the Channel variable here
 }
 
 checks() {
@@ -171,9 +169,6 @@ For example:
 echo \"$(id -un):100000:65536\" >> /etc/subgid"
 		exit 1
 	fi
-
-
-	# Add checks here to Channel to make sure if was set.  If it wasn't set, then we need to default it to testing
 }
 
 start_docker() {

--- a/rootless-install.sh
+++ b/rootless-install.sh
@@ -306,15 +306,18 @@ do_install() {
 	tmp=$(mktemp -d)
 	trap "rm -rf $tmp" EXIT INT TERM
 
+	# Download docker binary based on the build the user requested
+	BASE_STATIC_RELEASE_URL="https://download.docker.com/linux/static"
+	MASTER_STATIC_RELEASE_URL="https://master.dockerproject.org/linux/x86_64"
 	if [ -z "$CHANNEL" ] || [ "$CHANNEL" = "test" ]; then
-					STATIC_RELEASE_URL="https://download.docker.com/linux/static/test/x86_64/docker-19.03.0-beta4.tgz"
-					STATIC_RELEASE_ROOTLESS_URL="https://download.docker.com/linux/static/test/x86_64/docker-rootless-extras-19.03.0-beta4.tgz"
+					STATIC_RELEASE_URL="$BASE_STATIC_RELEASE_URL/test/x86_64/docker-19.03.0-beta4.tgz"
+					STATIC_RELEASE_ROOTLESS_URL="$BASE_STATIC_RELEASE_URL/test/x86_64/docker-rootless-extras-19.03.0-beta4.tgz"
 	elif [ "$CHANNEL" = "nightly" ]; then
-					STATIC_RELEASE_URL="https://download.docker.com/linux/static/nightly/docker-0.0.0-20190515210812-c58b5bc.tgz"
-					STATIC_RELEASE_ROOTLESS_URL="https://download.docker.com/linux/static/nightly/docker-rootless-extras-0.0.0-20190515210812-c58b5bc.tgz"
+					STATIC_RELEASE_URL="$BASE_STATIC_RELEASE_URL/nightly/docker-0.0.0-20190515210812-c58b5bc.tgz"
+					STATIC_RELEASE_ROOTLESS_URL="$BASE_STATIC_RELEASE_URL/nightly/docker-rootless-extras-0.0.0-20190515210812-c58b5bc.tgz"
 	elif [ "$CHANNEL" = "stable" ]; then
-					STATIC_RELEASE_URL="https://master.dockerproject.org/linux/x86_64/docker.tgz"
-					STATIC_RELEASE_ROOTLESS_URL="https://master.dockerproject.org/linux/x86_64/docker-rootless-extras.tgz"
+					STATIC_RELEASE_URL="$MASTER_STATIC_RELEASE_URL/docker.tgz"
+					STATIC_RELEASE_ROOTLESS_URL="$MASTER_STATIC_RELEASE_URL/docker-rootless-extras.tgz"
 	else
 					echo "Invalid option provided for CHANNEL: $CHANNEL, please provide one of the following: test, nightly, stable"
 	fi


### PR DESCRIPTION
**Description**
Based on issue # [112](https://github.com/docker/docker-install/issues/112), it looked like there was a need to install docker from multiple channels.  I took a pass at it.  Overall, it now provides three channels from which docker-ce can be installed: `test`, `stable`, and `nightly`.  

However it looks like the binaries need to be retagged as `docker.tgz` on: 
- https://download.docker.com/