### PR TITLE
Read debian dist from /etc/os-release from debian 10 onward

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -291,6 +291,9 @@ do_install() {
 		debian|raspbian)
 			dist_version="$(sed 's/\/.*//' /etc/debian_version | sed 's/\..*//')"
 			case "$dist_version" in
+				10)
+					dist_version="$(grep -Po 'VERSION_CODENAME=\K.*' /etc/os-release)"
+				;;
 				9)
 					dist_version="stretch"
 				;;


### PR DESCRIPTION
Hi,

Debian Buster repository is available, but get.docker.com does not support it. This produce a repository URL as `https://download.docker.com/linux/debian 10 Release` which is not valid.

I suggest to read codename from `/etc/os-release`. The commit still restrict the version number when to read this.

What do you think of this ?

Regards,