### PR TITLE
[TAR-916] Simplify CI, it was too complicated

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,75 +1,45 @@
 #!groovy
 
-def verifyTargets = [
-  'x86_64-verify-install-centos-7',
-  'x86_64-verify-install-fedora-29',
-  'x86_64-verify-install-ubuntu-xenial',
-  'x86_64-verify-install-ubuntu-bionic',
-]
+def VERSION="18.09"
 
-def armhfverifyTargets = [
-  'armhf-verify-install-ubuntu-xenial',
-  'armhf-verify-install-ubuntu-bionic',
-]
-
-def s390xverifyTargets = [
-  's390x-verify-install-ubuntu-xenial',
-  's390x-verify-install-ubuntu-bionic',
-]
-
-def aarch64verifyTargets = [
-  'aarch64-verify-install-ubuntu-xenial',
-  'aarch64-verify-install-ubuntu-bionic',
-  'aarch64-verify-install-centos-7',
-]
-
-def ppc64leverifyTargets = [
-  'ppc64le-verify-install-ubuntu-xenial',
-  'ppc64le-verify-install-ubuntu-bionic',
-]
-
-def genVerifyJob(String t, String label) {
-  return [ "${t}" : { ->
-    stage("${t}") {
-      wrappedNode(label: label, cleanWorkspace: true) {
-        checkout scm
-        channel = 'test'
-        if ("${env.JOB_NAME}".endsWith('get.docker.com')) {
-            channel='edge'
-        }
-        sh("make CHANNEL_TO_TEST=${channel} clean ${t}")
-        archiveArtifacts '*-verify-install-*'
-      }
+pipeline {
+    agent {
+        label "linux&&x86_64"
     }
-  } ]
-}
 
-wrappedNode(label: 'aufs', cleanWorkspace: true) {
-  stage('Shellcheck') {
-    checkout scm
-    sh('make shellcheck')
-  }
+    stages {
+        stage("shellcheck") {
+            steps {
+                sh "make shellcheck"
+            }
+        }
+        // Test out that the script will work for distros / version pinning
+        stage("Check distributions / version pinning") {
+            // NOTE: These can all technically run on the same node since they
+            // run in containers
+            parallel {
+                stage("Ubuntu 18.04") {
+                    steps {
+                        sh "TEST_IMAGE=ubuntu:18.04 make test"
+                    }
+                }
+                stage("Ubuntu 18.04 / version pinning") {
+                    steps {
+                        sh "TEST_IMAGE=ubuntu:18.04 VERSION=${VERSION} make test"
+                    }
+                }
+                stage("Centos 7") {
+                    steps {
+                        sh "TEST_IMAGE=centos:7 make test"
+                    }
+                }
+                stage("Centos 7 / version pinning") {
+                    steps {
+                        sh "TEST_IMAGE=centos:7 VERSION=${VERSION} make test"
+                    }
+                }
+            }
+        }
+        // TODO: add release step here to upload to S3
+    }
 }
-
-def verifyJobs = [:]
-for (t in verifyTargets) {
-  verifyJobs << genVerifyJob(t, 'aufs')
-}
-
-for (t in armhfverifyTargets) {
-  verifyJobs << genVerifyJob(t, 'armhf')
-}
-
-for (t in s390xverifyTargets) {
-  verifyJobs << genVerifyJob(t, 's390x-ubuntu-1604')
-}
-
-for (t in aarch64verifyTargets) {
-  verifyJobs << genVerifyJob(t, 'aarch64')
-}
-
-for (t in ppc64leverifyTargets) {
-  verifyJobs << genVerifyJob(t, 'ppc64le-ubuntu-1604')
-}
-
-parallel(verifyJobs)

--- a/Makefile
+++ b/Makefile
@@ -1,96 +1,33 @@
-SHELL:=/bin/bash
-DISTROS:=centos-7 fedora-28 fedora-29 debian-jessie debian-stretch debian-buster ubuntu-trusty ubuntu-xenial ubuntu-yakkety ubuntu-artful
-VERIFY_INSTALL_DISTROS:=$(addprefix x86_64-verify-install-,$(DISTROS))
-CHANNEL_TO_TEST?=test
+TEST_IMAGE?=ubuntu:18.04
 VERSION?=
+CHANNEL?=
+
+VOLUME_MOUNTS=-v "$(CURDIR)":/v
 SHELLCHECK_EXCLUSIONS=$(addprefix -e, SC1091 SC1117)
-SHELLCHECK=docker run --rm -v "$(CURDIR)":/v -w /v koalaman/shellcheck $(SHELLCHECK_EXCLUSIONS)
+SHELLCHECK=docker run --rm $(VOLUME_MOUNTS) -w /v koalaman/shellcheck $(SHELLCHECK_EXCLUSIONS)
+
+ENVSUBST_VARS=SCRIPT_COMMIT_SHA
+
+.PHONY: build
+
+build/install.sh: install.sh
+	mkdir -p $(@D)
+	SCRIPT_COMMIT_SHA='"$(shell git rev-parse HEAD)"' envsubst '$(addprefix $,$(ENVSUBST_VARS))' < $< > $@
 
 .PHONY: shellcheck
-shellcheck:
-	$(SHELLCHECK) install.sh
+shellcheck: build/install.sh
+	$(SHELLCHECK) $<
 
-.PHONY: check
-check: $(VERIFY_INSTALL_DISTROS)
+.PHONY: test
+test: build/install.sh
+	docker run --rm -i \
+		$(VOLUME_MOUNTS) \
+		-w /v \
+		-e VERSION \
+		-e CHANNEL \
+		$(TEST_IMAGE) \
+		sh "$<"
 
 .PHONY: clean
 clean:
-	$(RM) *-verify-install-*
-	$(RM) -r build
-
-x86_64-verify-install-%:
-	mkdir -p build
-	sed 's/DEFAULT_CHANNEL_VALUE="test"/DEFAULT_CHANNEL_VALUE="$(CHANNEL_TO_TEST)"/' install.sh > build/install.sh
-	set -o pipefail && docker run \
-		--rm \
-		-e VERSION \
-		-v $(CURDIR):/v \
-		-w /v \
-		$(subst -,:,$*) \
-		/v/verify-docker-install | tee $@
-
-armhf-verify-install-raspbian-jessie:
-	mkdir -p build
-	sed 's/DEFAULT_CHANNEL_VALUE="test"/DEFAULT_CHANNEL_VALUE="$(CHANNEL_TO_TEST)"/' install.sh > build/install.sh
-	set -o pipefail && docker run \
-		--rm \
-		-e VERSION \
-		-v $(CURDIR):/v \
-		-w /v \
-		resin/rpi-raspbian:jessie \
-		/v/verify-docker-install | tee $@
-
-armhf-verify-install-raspbian-stretch:
-	mkdir -p build
-	sed 's/DEFAULT_CHANNEL_VALUE="test"/DEFAULT_CHANNEL_VALUE="$(CHANNEL_TO_TEST)"/' install.sh > build/install.sh
-	set -o pipefail && docker run \
-		--rm \
-		-e VERSION \
-		-v $(CURDIR):/v \
-		-w /v \
-		resin/rpi-raspbian:stretch \
-		/v/verify-docker-install | tee $@
-
-armhf-verify-install-%:
-	mkdir -p build
-	sed 's/DEFAULT_CHANNEL_VALUE="test"/DEFAULT_CHANNEL_VALUE="$(CHANNEL_TO_TEST)"/' install.sh > build/install.sh
-	set -o pipefail && docker run \
-		--rm \
-		-e VERSION \
-		-v $(CURDIR):/v \
-		-w /v \
-		arm32v7/$(subst -,:,$*) \
-		/v/verify-docker-install | tee $@
-
-aarch64-verify-install-%:
-	mkdir -p build
-	sed 's/DEFAULT_CHANNEL_VALUE="test"/DEFAULT_CHANNEL_VALUE="$(CHANNEL_TO_TEST)"/' install.sh > build/install.sh
-	set -o pipefail && docker run \
-		--rm \
-		-e VERSION \
-		-v $(CURDIR):/v \
-		-w /v \
-		arm64v8/$(subst -,:,$*) \
-		/v/verify-docker-install | tee $@
-
-s390x-verify-install-%:
-	mkdir -p build
-	sed 's/DEFAULT_CHANNEL_VALUE="test"/DEFAULT_CHANNEL_VALUE="$(CHANNEL_TO_TEST)"/' install.sh > build/install.sh
-	set -o pipefail && docker run \
-		--rm \
-		-e VERSION \
-		-v $(CURDIR):/v \
-		-w /v \
-		s390x/$(subst -,:,$*) \
-		/v/verify-docker-install | tee $@
-
-ppc64le-verify-install-%:
-	mkdir -p build
-	sed 's/DEFAULT_CHANNEL_VALUE="test"/DEFAULT_CHANNEL_VALUE="$(CHANNEL_TO_TEST)"/' install.sh > build/install.sh
-	set -o pipefail && docker run \
-		--rm \
-		-e VERSION \
-		-v $(CURDIR):/v \
-		-w /v \
-		ppc64le/$(subst -,:,$*) \
-		/v/verify-docker-install | tee $@
+	$(RM) -r build/

--- a/install.sh
+++ b/install.sh
@@ -16,7 +16,7 @@ set -e
 #
 # Git commit from https://github.com/docker/docker-install when
 # the script was uploaded (Should only be modified by upload job):
-SCRIPT_COMMIT_SHA=UNKNOWN
+SCRIPT_COMMIT_SHA=${SCRIPT_COMMIT_SHA}
 
 
 # The channel to install from:


### PR DESCRIPTION
Simplifies CI to run through a simple `make test` target that has an
underlying `TEST_IMAGE` variable which determines the distribution to
run on.

Also changes the Jenkinsfile to be declarative since the old one kind of
sucked.

Also adds a test for version pinning since that's something we rely on a
lot.

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>