### PR TITLE
[TAR-917] ci: Update addprefix to add another `$`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,11 @@ SHELLCHECK=docker run --rm $(VOLUME_MOUNTS) -w /v koalaman/shellcheck $(SHELLCHE
 ENVSUBST_VARS=SCRIPT_COMMIT_SHA
 
 .PHONY: build
+build: build/install.sh
 
 build/install.sh: install.sh
 	mkdir -p $(@D)
-	SCRIPT_COMMIT_SHA='"$(shell git rev-parse HEAD)"' envsubst '$(addprefix $,$(ENVSUBST_VARS))' < $< > $@
+	SCRIPT_COMMIT_SHA='$(shell git rev-parse HEAD)' envsubst '$(addprefix $$,$(ENVSUBST_VARS))' < $< > $@
 
 .PHONY: shellcheck
 shellcheck: build/install.sh

--- a/Makefile
+++ b/Makefile
@@ -6,14 +6,14 @@ VOLUME_MOUNTS=-v "$(CURDIR)":/v
 SHELLCHECK_EXCLUSIONS=$(addprefix -e, SC1091 SC1117)
 SHELLCHECK=docker run --rm $(VOLUME_MOUNTS) -w /v koalaman/shellcheck $(SHELLCHECK_EXCLUSIONS)
 
-ENVSUBST_VARS=SCRIPT_COMMIT_SHA
+ENVSUBST_VARS=LOAD_SCRIPT_COMMIT_SHA
 
 .PHONY: build
 build: build/install.sh
 
 build/install.sh: install.sh
 	mkdir -p $(@D)
-	SCRIPT_COMMIT_SHA='$(shell git rev-parse HEAD)' envsubst '$(addprefix $$,$(ENVSUBST_VARS))' < $< > $@
+	LOAD_SCRIPT_COMMIT_SHA='$(shell git rev-parse HEAD)' envsubst '$(addprefix $$,$(ENVSUBST_VARS))' < $< > $@
 
 .PHONY: shellcheck
 shellcheck: build/install.sh

--- a/install.sh
+++ b/install.sh
@@ -16,9 +16,7 @@ set -e
 #
 # Git commit from https://github.com/docker/docker-install when
 # the script was uploaded (Should only be modified by upload job):
-
-# shellcheck disable=SC2140
-SCRIPT_COMMIT_SHA="${SCRIPT_COMMIT_SHA}"
+SCRIPT_COMMIT_SHA="${LOAD_SCRIPT_COMMIT_SHA}"
 
 
 # The channel to install from:

--- a/install.sh
+++ b/install.sh
@@ -16,7 +16,9 @@ set -e
 #
 # Git commit from https://github.com/docker/docker-install when
 # the script was uploaded (Should only be modified by upload job):
-SCRIPT_COMMIT_SHA=${SCRIPT_COMMIT_SHA}
+
+# shellcheck disable=SC2140
+SCRIPT_COMMIT_SHA="${SCRIPT_COMMIT_SHA}"
 
 
 # The channel to install from:


### PR DESCRIPTION
the envsubst wasn't working correctly on ubuntu due to the `$` getting
stripped by make during the `addprefix`

Should now work correctly no matter what distribution you're on.

Bug was introduced in #131 

Also fixes the `build` target not pointing to anything

Signed-off-by: Eli Uriegas <eli.uriegas@docker.com>