### PR TITLE
Fix pending issue by interactive installation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -351,7 +351,7 @@ do_install() {
 					set -x
 				fi
 				$sh_c 'apt-get update -qq >/dev/null'
-				$sh_c "apt-get install -y -qq $pre_reqs >/dev/null"
+				$sh_c "DEBIAN_FRONTEND=noninteractive apt-get install -y -qq $pre_reqs >/dev/null"
 				$sh_c "curl -fsSL \"$DOWNLOAD_URL/linux/$lsb_dist/gpg\" | apt-key add -qq - >/dev/null"
 				$sh_c "echo \"$apt_repo\" > /etc/apt/sources.list.d/docker.list"
 				$sh_c 'apt-get update -qq >/dev/null'


### PR DESCRIPTION
An interactive step is needed by libssl1.1:amd64 to config itself. User must chose Yes/No about "Restart services during package upgrades without asking?" via frontend. "DEBIAN_FRONTEND=noninteractive" will make default options be chosen and no interruption in the process.
This is tested on Ubuntu 18.