### PR TITLE
Allow to overwrite BIN variable

### DIFF
--- a/rootless-install.sh
+++ b/rootless-install.sh
@@ -18,7 +18,9 @@ SCRIPT_COMMIT_SHA=UNKNOWN
 set -e
 
 init_vars() {
-	BIN="${DOCKER_BIN:-$HOME/bin}"
+	if [ -z "$BIN" ]; then
+		BIN="${DOCKER_BIN:-$HOME/bin}"
+	fi
 
 	DAEMON=dockerd
 	SYSTEMD=


### PR DESCRIPTION
It adds the ability to choose where to install Docker-rootless if the `BIN` environment variable is set, otherwise it defaults to `$HOME/bin`.