### PR TITLE
Fix unable to re-open stdin warnings

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -345,16 +345,17 @@ do_install() {
 			if ! command -v gpg > /dev/null; then
 				pre_reqs="$pre_reqs gnupg"
 			fi
+            apt_get='DEBIAN_FRONTEND=noninteractive apt-get'
 			apt_repo="deb [arch=$(dpkg --print-architecture)] $DOWNLOAD_URL/linux/$lsb_dist $dist_version $CHANNEL"
 			(
 				if ! is_dry_run; then
 					set -x
 				fi
-				$sh_c 'apt-get update -qq >/dev/null'
-				$sh_c "DEBIAN_FRONTEND=noninteractive apt-get install -y -qq $pre_reqs >/dev/null"
+				$sh_c "$apt_get update -qq >/dev/null"
+				$sh_c "$apt_get install -y -qq $pre_reqs >/dev/null"
 				$sh_c "curl -fsSL \"$DOWNLOAD_URL/linux/$lsb_dist/gpg\" | apt-key add -qq - >/dev/null"
 				$sh_c "echo \"$apt_repo\" > /etc/apt/sources.list.d/docker.list"
-				$sh_c 'apt-get update -qq >/dev/null'
+				$sh_c "$apt_get update -qq >/dev/null"
 			)
 			pkg_version=""
 			if [ -n "$VERSION" ]; then
@@ -384,9 +385,9 @@ do_install() {
 					set -x
 				fi
 				if [ -n "$cli_pkg_version" ]; then
-					$sh_c "apt-get install -y -qq --no-install-recommends docker-ce-cli=$cli_pkg_version >/dev/null"
+					$sh_c "$apt_get install -y -qq --no-install-recommends docker-ce-cli=$cli_pkg_version >/dev/null"
 				fi
-				$sh_c "apt-get install -y -qq --no-install-recommends docker-ce$pkg_version >/dev/null"
+				$sh_c "$apt_get install -y -qq --no-install-recommends docker-ce$pkg_version >/dev/null"
 			)
 			echo_docker_as_nonroot
 			exit 0


### PR DESCRIPTION
This fixes the warning showed in console log when trying to run apt-get install from a non interactive terminal. Warning is: `dpkg-reconfigure: unable to re-open stdin: No file or directory.`