### PR TITLE
Use shellcheck stable image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CHANNEL?=
 
 VOLUME_MOUNTS=-v "$(CURDIR)":/v
 SHELLCHECK_EXCLUSIONS=$(addprefix -e, SC1091 SC1117)
-SHELLCHECK=docker run --rm $(VOLUME_MOUNTS) -w /v koalaman/shellcheck $(SHELLCHECK_EXCLUSIONS)
+SHELLCHECK=docker run --rm $(VOLUME_MOUNTS) -w /v koalaman/shellcheck:stable $(SHELLCHECK_EXCLUSIONS)
 
 ENVSUBST_VARS=LOAD_SCRIPT_COMMIT_SHA
 


### PR DESCRIPTION
This PR probably fixes the issue that we saw some months ago
```
shellcheck: src/ShellCheck/Analytics.hs:1404:10-27: No instance nor default method for class operation mappend
```
in https://ci.docker.com/public/blue/organizations/jenkins/docker-install/detail/PR-149/2/pipeline/
Use the stable shellcheck image instead.

