### PR TITLE
Update GitHub Actions configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ jobs:
           - centos:7
         version:
           - 19.03
-          - 18.09
           - ""
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     strategy:
       matrix:
         os:


### PR DESCRIPTION
- GH Actions: set 5 minute timeout for the tests
  GitHub Actions have a default timeout of 6 hours, which is waaaay to high.
  This updates the timeout to 5 minutes (they currently run in just over a minutes, so for now this should be enough).
- GH Actions: remove 18.09 as it reached EOL