### PR TITLE
rootless-install.sh: use safer XRD on non-systemd hosts

### DIFF
--- a/rootless-install.sh
+++ b/rootless-install.sh
@@ -101,8 +101,8 @@ checks() {
 			>&2 echo "- or simply log back in as the desired unprivileged user (ssh works for remote machines)"
 			exit 1
 		fi
-		export XDG_RUNTIME_DIR="/tmp/docker-$(id -u)"
-		mkdir -p "$XDG_RUNTIME_DIR"
+		export XDG_RUNTIME_DIR="$HOME/.docker/run"
+		mkdir -p -m 700 "$XDG_RUNTIME_DIR"
 		XDG_RUNTIME_DIR_CREATED=1
 	fi
 
@@ -307,6 +307,7 @@ print_instructions() {
 	echo "# Make sure the following environment variables are set (or add them to ~/.bashrc):\n"
 
 	if [ -n "$XDG_RUNTIME_DIR_CREATED" ]; then
+		echo "# WARN: systemd not found. You have to remove XDG_RUNTIME_DIR manually on every logout."
 		echo "export XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR"
 	fi
 


### PR DESCRIPTION
`/tmp/docker-$(id -u)` is not a good candidate as `$XDG_RUNTIME_DIR`, because it might be already created by another user.

The new path is `$HOME/.docker/run`.

This commit does not affect systemd-based hosts.
