### PR TITLE
rootless (nightly): set PATH="$BIN:$PATH" before running setup tool

### DIFF
--- a/rootless-install.sh
+++ b/rootless-install.sh
@@ -350,7 +350,7 @@ exec_setuptool() {
 	fi
 	(
 		set -x
-		"$BIN/dockerd-rootless-setuptool.sh" install "$@"
+		PATH="$BIN:$PATH" "$BIN/dockerd-rootless-setuptool.sh" install "$@"
 	)
 }
 


### PR DESCRIPTION
Previously, it was failing with the following error when `$BIN` is not present in `$PATH`:

```
+ /home/vagrant/bin/dockerd-rootless-setuptool.sh install
[ERROR] dockerd-rootless.sh needs to be present under $PATH
```