### PR TITLE
make sure certificates are up-to-date

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -369,6 +369,8 @@ do_install() {
 				fi
 				$sh_c 'apt-get update -qq >/dev/null'
 				$sh_c "DEBIAN_FRONTEND=noninteractive apt-get install -y -qq $pre_reqs >/dev/null"
+				# Make sure ca-certificates are up-to-date
+				$sh_c "update-ca-certificates -f"
 				$sh_c "curl -fsSL \"$DOWNLOAD_URL/linux/$lsb_dist/gpg\" | apt-key add -qq - >/dev/null"
 				$sh_c "echo \"$apt_repo\" > /etc/apt/sources.list.d/docker.list"
 				$sh_c 'apt-get update -qq >/dev/null'


### PR DESCRIPTION
Found a TODO about this in one of our internal test-scripts to include this step in the get.docker.com install script.
