### PR TITLE
Use add-apt-repository if available.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -384,7 +384,7 @@ do_install() {
 				$sh_c 'apt-get update -qq >/dev/null'
 				$sh_c "DEBIAN_FRONTEND=noninteractive apt-get install -y -qq $pre_reqs >/dev/null"
 				$sh_c "curl -fsSL \"$DOWNLOAD_URL/linux/$lsb_dist/gpg\" | apt-key add -qq - >/dev/null"
-				$sh_c "add-apt-repository \"$apt_repo\" || echo \"$apt_repo\" > /etc/apt/sources.list.d/docker.list"
+				$sh_c "([ $lsb_dist = "raspbian" ] && add-apt-repository \"$apt_repo\") || echo \"$apt_repo\" > /etc/apt/sources.list.d/docker.list"
 				$sh_c 'apt-get update -qq >/dev/null'
 			)
 			pkg_version=""

--- a/install.sh
+++ b/install.sh
@@ -384,7 +384,7 @@ do_install() {
 				$sh_c 'apt-get update -qq >/dev/null'
 				$sh_c "DEBIAN_FRONTEND=noninteractive apt-get install -y -qq $pre_reqs >/dev/null"
 				$sh_c "curl -fsSL \"$DOWNLOAD_URL/linux/$lsb_dist/gpg\" | apt-key add -qq - >/dev/null"
-				$sh_c "add-apt-repository \"$apt_repo\""
+				$sh_c "add-apt-repository \"$apt_repo\" || echo \"$apt_repo\" > /etc/apt/sources.list.d/docker.list"
 				$sh_c 'apt-get update -qq >/dev/null'
 			)
 			pkg_version=""

--- a/install.sh
+++ b/install.sh
@@ -384,7 +384,7 @@ do_install() {
 				$sh_c 'apt-get update -qq >/dev/null'
 				$sh_c "DEBIAN_FRONTEND=noninteractive apt-get install -y -qq $pre_reqs >/dev/null"
 				$sh_c "curl -fsSL \"$DOWNLOAD_URL/linux/$lsb_dist/gpg\" | apt-key add -qq - >/dev/null"
-				$sh_c "([ $lsb_dist = "raspbian" ] && add-apt-repository \"$apt_repo\") || echo \"$apt_repo\" > /etc/apt/sources.list.d/docker.list"
+				$sh_c "([ $lsb_dist = \"raspbian\" ] && add-apt-repository \"$apt_repo\") || echo \"$apt_repo\" > /etc/apt/sources.list.d/docker.list"
 				$sh_c 'apt-get update -qq >/dev/null'
 			)
 			pkg_version=""

--- a/install.sh
+++ b/install.sh
@@ -384,7 +384,7 @@ do_install() {
 				$sh_c 'apt-get update -qq >/dev/null'
 				$sh_c "DEBIAN_FRONTEND=noninteractive apt-get install -y -qq $pre_reqs >/dev/null"
 				$sh_c "curl -fsSL \"$DOWNLOAD_URL/linux/$lsb_dist/gpg\" | apt-key add -qq - >/dev/null"
-				$sh_c "([ $lsb_dist = \"raspbian\" ] && add-apt-repository \"$apt_repo\") || echo \"$apt_repo\" > /etc/apt/sources.list.d/docker.list"
+				$sh_c "([ $lsb_dist != \"raspbian\" ] && add-apt-repository \"$apt_repo\") || echo \"$apt_repo\" > /etc/apt/sources.list.d/docker.list"
 				$sh_c 'apt-get update -qq >/dev/null'
 			)
 			pkg_version=""

--- a/install.sh
+++ b/install.sh
@@ -384,7 +384,7 @@ do_install() {
 				$sh_c 'apt-get update -qq >/dev/null'
 				$sh_c "DEBIAN_FRONTEND=noninteractive apt-get install -y -qq $pre_reqs >/dev/null"
 				$sh_c "curl -fsSL \"$DOWNLOAD_URL/linux/$lsb_dist/gpg\" | apt-key add -qq - >/dev/null"
-				$sh_c "echo \"$apt_repo\" > /etc/apt/sources.list.d/docker.list"
+				$sh_c "add-apt-repository \"$apt_repo\""
 				$sh_c 'apt-get update -qq >/dev/null'
 			)
 			pkg_version=""


### PR DESCRIPTION
add-apt-repository is capable of seamlessly handling proxy settings.