### PR TITLE
support AlmaLinux

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -342,7 +342,7 @@ do_install() {
 			esac
 		;;
 
-		centos|rhel)
+		centos|rhel|almalinux)
 			if [ -z "$dist_version" ] && [ -r /etc/os-release ]; then
 				dist_version="$(. /etc/os-release && echo "$VERSION_ID")"
 			fi
@@ -427,7 +427,11 @@ do_install() {
 			echo_docker_as_nonroot
 			exit 0
 			;;
-		centos|fedora|rhel)
+		centos|fedora|rhel|almalinux)
+			if [ "$lsb_dist" = "almalinux" ]; then
+				echo "INFO: using CentOS packages"
+				lsb_dist="centos"
+			fi
 			yum_repo="$DOWNLOAD_URL/linux/$lsb_dist/$REPO_FILE"
 			if ! curl -Ifs "$yum_repo" > /dev/null; then
 				echo "Error: Unable to curl repository file $yum_repo, is it valid?"


### PR DESCRIPTION
CentOS 8 is deprecated, so other RHEL8-compatible distros such as AlmaLinux (https://almalinux.org/) should be supported.

RockyLinux also should be supported in future, but RockyLinux is not available as ISO images yet.
