### PR TITLE
Handle CentOS forks

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -120,6 +120,13 @@ get_distribution() {
 	if [ -r /etc/os-release ]; then
 		lsb_dist="$(. /etc/os-release && echo "$ID")"
 	fi
+	# Updates the "lsb_dist" variable for the CentOS forks
+	# new IDs will be updated in the future.
+	case "$lsb_dist" in
+		almalinux)
+			lsb_dist="centos"
+			;;
+	esac
 	# Returning an empty string here should be alright since the
 	# case statements don't act unless you provide an actual value
 	echo "$lsb_dist"


### PR DESCRIPTION
Since CentOS 8 going into a rolling release mode with CentOS Stream, new forks have appeared for keeping the "stable release".

The first one to be available is Almalinux and the current script does not support it.

This PR addresses this gap, and as I don't yet the name/IDs of the future forks, I decided to go with a `case` statement, as it will be easier to manage in the long run.

By adding the `case` statement in the `get_distribution()` function, this avoids any impact on the creation of the distribution URL used in the script.

Finally, this fixes the issue in the Moby repo: https://github.com/moby/moby/issues/42337

Signed-off-by: nunix corsair@hey.com