### PR TITLE
remove warning about pre-1.10 update

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -221,33 +221,10 @@ check_forked() {
 	fi
 }
 
-semverParse() {
-	major="${1%%.*}"
-	minor="${1#$major.}"
-	minor="${minor%%.*}"
-	patch="${1#$major.$minor.}"
-	patch="${patch%%[-.]*}"
-}
-
 do_install() {
 	echo "# Executing docker install script, commit: $SCRIPT_COMMIT_SHA"
 
 	if command_exists docker; then
-		docker_version="$(docker -v | cut -d ' ' -f3 | cut -d ',' -f1)"
-		MAJOR_W=1
-		MINOR_W=10
-
-		semverParse "$docker_version"
-
-		shouldWarn=0
-		if [ "$major" -lt "$MAJOR_W" ]; then
-			shouldWarn=1
-		fi
-
-		if [ "$major" -le "$MAJOR_W" ] && [ "$minor" -lt "$MINOR_W" ]; then
-			shouldWarn=1
-		fi
-
 		cat >&2 <<-'EOF'
 			Warning: the "docker" command appears to already exist on this system.
 
@@ -256,23 +233,7 @@ do_install() {
 			installation.
 
 			If you installed the current Docker package using this script and are using it
-		EOF
-
-		if [ $shouldWarn -eq 1 ]; then
-			cat >&2 <<-'EOF'
-			again to update Docker, we urge you to migrate your image store before upgrading
-			to v1.10+.
-
-			You can find instructions for this here:
-			https://github.com/docker/docker/wiki/Engine-v1.10.0-content-addressability-migration
-			EOF
-		else
-			cat >&2 <<-'EOF'
 			again to update Docker, you can safely ignore this message.
-			EOF
-		fi
-
-		cat >&2 <<-'EOF'
 
 			You may press Ctrl+C now to abort this script.
 		EOF


### PR DESCRIPTION
When upgrading docker from versions older than v1.10, the image store must be migrated for the content-addressable store.

Docker 1.10 was released more than 5 years ago, so people running versions older than that, probably have more urgent things to be concerned about, so removing this warning.
