### PR TITLE
Add deprecation warning for Ubuntu Xenial (16.05) and other EOL distro versions

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -148,11 +148,14 @@ is_darwin() {
 
 deprecation_notice() {
 	distro=$1
-	date=$2
+	distro_version=$2
 	echo
-	echo "DEPRECATION WARNING:"
-	echo "    The distribution, $distro, will no longer be supported in this script as of $date."
-	echo "    If you feel this is a mistake please submit an issue at https://github.com/docker/docker-install/issues/new"
+	printf "\033[91;1mDEPRECATION WARNING\033[0m\n"
+	printf "    This Linux distribution (\033[1m%s %s\033[0m) reached end-of-life and is no longer supported by this script.\n" "$distro" "$distro_version"
+	echo   "    No updates or security fixes will be released for this distribution, and users are recommended"
+	echo   "    to upgrade to a currently maintained version of $distro."
+	echo
+	printf   "Press \033[1mCtrl+C\033[0m now to abort this script, or wait for the installation to continue."
 	echo
 	sleep 10
 }
@@ -365,6 +368,25 @@ do_install() {
 
 	# Check if this is a forked Linux distro
 	check_forked
+
+	# Print deprecation warnings for distro versions that recently reached EOL,
+	# but may still be commonly used (especially LTS versions).
+	case "$lsb_dist.$dist_version" in
+		debian.stretch|debian.jessie)
+			deprecation_notice "$lsb_dist" "$dist_version"
+			;;
+		raspbian.stretch|raspbian.jessie)
+			deprecation_notice "$lsb_dist" "$dist_version"
+			;;
+		ubuntu.xenial|ubuntu.trusty)
+			deprecation_notice "$lsb_dist" "$dist_version"
+			;;
+		fedora.*)
+			if [ "$dist_version" -lt 33 ]; then
+				deprecation_notice "$lsb_dist" "$dist_version"
+			fi
+			;;
+	esac
 
 	# Run setup for each distro accordingly
 	case "$lsb_dist" in


### PR DESCRIPTION
This adds a deprecation warning for distro versions that reached EOL, and for which we no longer maintain updates.

Note that the list of versions for which we produce warnings is not "complete", and only contains versions that either reached EOL recently, or LTS versions that may still be commonly in use.

With this patch;

Running inside a fedora:32 container:

    DEPRECATION WARNING
        This Linux distribution (fedora 32) reached end-of-life and is no longer supported by this script.
        No updates or security fixes will be released for this distribution, and users are recommended
        to upgrade to a currently maintained version of fedora.

    Press Ctrl+C now to abort this script, or wait for the installation to continue.
    ^C

Running inside an ubuntu:xenial container:

    DEPRECATION WARNING
        This Linux distribution (ubuntu xenial) reached end-of-life and is no longer supported by this script.
        No updates or security fixes will be released for this distribution, and users are recommended
        to upgrade to a currently maintained version of ubuntu.

    Press Ctrl+C now to abort this script, or wait for the installation to continue.
    ^C


Screenshot:

<img width="756" alt="Screenshot 2021-07-04 at 12 14 14" src="https://user-images.githubusercontent.com/1804568/124383100-f95c1c80-dcca-11eb-9a49-89e8e081641f.png">
