### PR TITLE
Add Debian Bullseye codename

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -329,6 +329,9 @@ do_install() {
 		debian|raspbian)
 			dist_version="$(sed 's/\/.*//' /etc/debian_version | sed 's/\..*//')"
 			case "$dist_version" in
+				11)
+					dist_version="bullseye"
+				;;
 				10)
 					dist_version="buster"
 				;;


### PR DESCRIPTION
Otherwise install fails if it uses "11":

    apt-get update -qq >/dev/null
    E: The repository 'https://download-stage.docker.com/linux/debian 11 Release' does not have a Release file.
