### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ curl -fsSL https://test.docker.com -o test-docker.sh
 sh test-docker.sh
 ```
 
-From the source repo (This will install latest from the `test` channel):
+From the source repo (This will install latest from the `stable` channel):
 ```shell
 sh install.sh
 ```


### PR DESCRIPTION
This commit https://github.com/docker/docker-install/commit/51a9fbfd1dae4097d9666a72b566dba68d1d4bc7 changed the default channel from 'test' to 'stable'