### PR TITLE
Update install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -401,6 +401,7 @@ do_install() {
 				$sh_c 'apt-get update -qq >/dev/null'
 				$sh_c "DEBIAN_FRONTEND=noninteractive apt-get install -y -qq $pre_reqs >/dev/null"
 				$sh_c "curl -fsSL \"$DOWNLOAD_URL/linux/$lsb_dist/gpg\" | gpg --dearmor --yes -o /usr/share/keyrings/docker-archive-keyring.gpg"
+				$sh_c "chmod a+r /usr/share/keyrings/docker-archive-keyring.gpg"
 				$sh_c "echo \"$apt_repo\" > /etc/apt/sources.list.d/docker.list"
 				$sh_c 'apt-get update -qq >/dev/null'
 			)


### PR DESCRIPTION
Following https://stackoverflow.com/a/68764068 to make it work on Debian & Ubuntu cloud  images (LXD, AWS, ...)

Edit : after investigation, on my Debian 11 LXD container, my umask was 0027, therefore the key file `/usr/share/keyrings/docker-archive-keyring.gpg` was not world readable.
Nevertheless I think this pull request is still relevant to make the script work whatever the umask is...