### PR TITLE
fix GPG error (docker-archive-keyring.gpg)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -401,6 +401,7 @@ do_install() {
 				$sh_c 'apt-get update -qq >/dev/null'
 				$sh_c "DEBIAN_FRONTEND=noninteractive apt-get install -y -qq $pre_reqs >/dev/null"
 				$sh_c "curl -fsSL \"$DOWNLOAD_URL/linux/$lsb_dist/gpg\" | gpg --dearmor --yes -o /usr/share/keyrings/docker-archive-keyring.gpg"
+				$sh_c "sudo chmod a+r /usr/share/keyrings/docker-archive-keyring.gpg"
 				$sh_c "echo \"$apt_repo\" > /etc/apt/sources.list.d/docker.list"
 				$sh_c 'apt-get update -qq >/dev/null'
 			)


### PR DESCRIPTION
file /usr/share/keyrings/docker-archive-keyring.gpg is wrong permissions, cause error: "W: GPG error: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 7EA0A9C3F273FCD8"

This command will fix it: "sudo chmod a+r /usr/share/keyrings/docker-archive-keyring.gpg"

source: https://stackoverflow.com/a/68764068