### PR TITLE
install.sh: set read-permissions for environments with non-standard umask

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -401,6 +401,7 @@ do_install() {
 				$sh_c 'apt-get update -qq >/dev/null'
 				$sh_c "DEBIAN_FRONTEND=noninteractive apt-get install -y -qq $pre_reqs >/dev/null"
 				$sh_c "curl -fsSL \"$DOWNLOAD_URL/linux/$lsb_dist/gpg\" | gpg --dearmor --yes -o /usr/share/keyrings/docker-archive-keyring.gpg"
+				$sh_c "chmod a+r /usr/share/keyrings/docker-archive-keyring.gpg"
 				$sh_c "echo \"$apt_repo\" > /etc/apt/sources.list.d/docker.list"
 				$sh_c 'apt-get update -qq >/dev/null'
 			)


### PR DESCRIPTION
- fixes https://github.com/docker/docker-install/issues/244
- closes https://github.com/docker/docker-install/pull/256
- closes https://github.com/docker/docker-install/pull/269

Some environments may have a non-standard (non 022) umask set, in which case
the keyring would not get read-permissions for all users, which lead to errors
during install:

    W: GPG error: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 7EA0A9C3F273FCD8

This commit changes the permissions of the file, so that it's world-readable.
See https://stackoverflow.com/a/68764068

Co-Authored-By: ManhIT <manhit@s-developers.com>
Co-Authored-By: Hervé M <hmag@users.noreply.github.com>
Signed-off-by: Sebastiaan van Stijn <github@gone.nl>