### PR TITLE
rootless-install.sh: fix some shellcheck warnings

### DIFF
--- a/rootless-install.sh
+++ b/rootless-install.sh
@@ -156,7 +156,7 @@ dnf install -y iptables"
 	fi
 
 	# ip_tables module dependency check
-	if [ -z "$SKIP_IPTABLES" ] && ! lsmod | grep ip_tables >/dev/null 2>&1 && ! cat /lib/modules/$(uname -r)/modules.builtin | grep ip_tables >/dev/null 2>&1; then
+	if [ -z "$SKIP_IPTABLES" ] && ! lsmod | grep ip_tables >/dev/null 2>&1 && ! grep -q ip_tables "/lib/modules/$(uname -r)/modules.builtin"; then
 			INSTRUCTIONS="${INSTRUCTIONS}
 modprobe ip_tables"
 	fi
@@ -225,11 +225,13 @@ exec_setuptool() {
 }
 
 do_install() {
+	echo "# Executing docker rootless install script, commit: $SCRIPT_COMMIT_SHA"
+
 	init_vars
 	checks
 
 	tmp=$(mktemp -d)
-	trap "rm -rf $tmp" EXIT INT TERM
+	trap 'rm -rf "$tmp"' EXIT INT TERM
 	# Download tarballs docker-* and docker-rootless-extras=*
 	(
 		cd "$tmp"


### PR DESCRIPTION
Fixes some shellcheck linting warnings:

- [SC2034][SC2034]: "SCRIPT_COMMIT_SHA appears unused. Verify use (or export if used externally)."
- [SC2046][SC2046]: "Quote this to prevent word splitting"
- [SC2002][SC2002]: "Useless cat. Consider cmd < file | .. or cmd file | .. instead"
- [SC2064][SC2064]: "Use single quotes, otherwise this expands now rather than when signalled."

[SC2034]: https://github.com/koalaman/shellcheck/wiki/SC2034
[SC2002]: https://github.com/koalaman/shellcheck/wiki/SC2002
[SC2046]: https://github.com/koalaman/shellcheck/wiki/SC2046
[SC2064]: https://github.com/koalaman/shellcheck/wiki/SC2064
