### PR TITLE
Fix zypper command syntax

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -617,7 +617,7 @@ do_install() {
 				if ! is_dry_run; then
 					set -x
 				fi
-				$sh_c "zypper install -y -q $pkgs"
+				$sh_c "zypper -q install -y $pkgs"
 			)
 			echo_docker_as_nonroot
 			exit 0


### PR DESCRIPTION
`zypper install -y -q <package>` throws an error "The flag q is not known". Fixed the same.

Signed-off-by: Prabhav Thali <Prabhav.Thali1@ibm.com>