### PR TITLE
Explicitly install containerd.io to handle upgrades

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -433,8 +433,8 @@ do_install() {
 			(
 				pkgs="docker-ce${pkg_version%=}"
 				if version_gte "18.09"; then
-						# older versions don't support a cli package
-						pkgs="$pkgs docker-ce-cli${cli_pkg_version%=}"
+						# older versions didn't ship the cli and containerd as separate packages
+						pkgs="$pkgs docker-ce-cli${cli_pkg_version%=} containerd.io"
 				fi
 				if version_gte "20.10"; then
 						pkgs="$pkgs docker-compose-plugin"
@@ -521,11 +521,11 @@ do_install() {
 			(
 				pkgs="docker-ce$pkg_version"
 				if version_gte "18.09"; then
-					# older versions don't support a cli package
+					# older versions didn't ship the cli and containerd as separate packages
 					if [ -n "$cli_pkg_version" ]; then
-						pkgs="$pkgs docker-ce-cli-$cli_pkg_version"
+						pkgs="$pkgs docker-ce-cli-$cli_pkg_version containerd.io"
 					else
-						pkgs="$pkgs docker-ce-cli"
+						pkgs="$pkgs docker-ce-cli containerd.io"
 					fi
 				fi
 				if version_gte "20.10" && [ "$(uname -m)" = "x86_64" ]; then
@@ -606,9 +606,10 @@ do_install() {
 				pkgs="docker-ce$pkg_version"
 				if version_gte "18.09"; then
 					if [ -n "$cli_pkg_version" ]; then
-						pkgs="$pkgs docker-ce-cli-$cli_pkg_version"
+						# older versions didn't ship the cli and containerd as separate packages
+						pkgs="$pkgs docker-ce-cli-$cli_pkg_version containerd.io"
 					else
-						pkgs="$pkgs docker-ce-cli"
+						pkgs="$pkgs docker-ce-cli containerd.io"
 					fi
 				fi
 				if version_gte "20.10"; then


### PR DESCRIPTION
- handles the remaining bits of https://github.com/docker/docker-install/pull/195
- supersedes https://github.com/docker/docker-install/pull/195
- closes https://github.com/docker/docker-install/pull/195


While the script isn't intended for updating existing installations,
some users use it for that purpose, and when doing so may end up in
a situation where only the docker packages are updated, but containerd
is kept at the already installed version.

This patch explicitly installs the containerd.io package so that running
the script on an existing installation also updates the containerd.io
package to the latest version.

Docker packages before 18.09 bundled containerd in the docker-ce package,
so this step is made options based on the version that's requested to be
installed (defaults to "latest").
