### PR TITLE
install docker-buildx-plugin on version 20.10 as well, to allow upgrading

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -538,10 +538,7 @@ do_install() {
 						pkgs="$pkgs docker-ce-cli${cli_pkg_version%=} containerd.io"
 				fi
 				if version_gte "20.10"; then
-						pkgs="$pkgs docker-compose-plugin docker-ce-rootless-extras$pkg_version"
-				fi
-				if version_gte "23.0"; then
-						pkgs="$pkgs docker-buildx-plugin"
+						pkgs="$pkgs docker-buildx-plugin docker-compose-plugin docker-ce-rootless-extras$pkg_version"
 				fi
 				if ! is_dry_run; then
 					set -x
@@ -628,10 +625,7 @@ do_install() {
 					fi
 				fi
 				if version_gte "20.10"; then
-					pkgs="$pkgs docker-compose-plugin docker-ce-rootless-extras$pkg_version"
-				fi
-				if version_gte "23.0"; then
-						pkgs="$pkgs docker-buildx-plugin"
+					pkgs="$pkgs docker-buildx-plugin docker-compose-plugin docker-ce-rootless-extras$pkg_version"
 				fi
 				if ! is_dry_run; then
 					set -x
@@ -701,10 +695,7 @@ do_install() {
 					fi
 				fi
 				if version_gte "20.10"; then
-					pkgs="$pkgs docker-compose-plugin docker-ce-rootless-extras$pkg_version"
-				fi
-				if version_gte "23.0"; then
-						pkgs="$pkgs docker-buildx-plugin"
+					pkgs="$pkgs docker-buildx-plugin docker-compose-plugin docker-ce-rootless-extras$pkg_version"
 				fi
 				if ! is_dry_run; then
 					set -x


### PR DESCRIPTION
### install docker-buildx-plugin on version 20.10 as well, to allow upgrading

The `docker-buildx-plugin` package can replace the version of buildx that's
bundled in the `docker-ce-cli` packages. This allows for buildx to be updated
to the current version, even if it was originally installed from the bundled
version.

Some testing shows that this works well, and that upgrading the `docker-ce-cli`
package won't revert the change, and continues using the buildx version from the
separate package.

Here's some steps to illustrate that scenario:

```console
# remove any installed docker packages
apt-get purge -y docker-ce docker-ce-cli containerd.io docker-compose-plugin docker-scan-plugin docker-buildx-plugin docker-ce-rootless-extras

# stop the docker.socket service (it blocks a clean reinstall after an uninstall)
systemctl stop docker.socket

# install docker 20.10.14 (from the test channel)
curl -fsSL https://test.docker.com | VERSION=20.10.14 sh

# verify that the installed version of buildx is the bundled (`-docker`) version:
docker buildx version
github.com/docker/buildx v0.8.1-docker 5fac64c2c49dae1320f2b51f1a899ca451935554

# install the separate `docker-buildx-plugin` package
apt-get install -y docker-buildx-plugin

# verify that it replaced the bundled version
docker buildx version
github.com/docker/buildx v0.8.2

# upgrade to docker 20.10.17
curl -fsSL https://test.docker.com | VERSION=20.10.17 sh

# verify that updating didn't downgrade the buildx plugin, or revert it to the "included" buildx version:
docker buildx version
github.com/docker/buildx v0.8.2
```
