### PR TITLE
Updated the mirror repo's URL

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -66,8 +66,8 @@ case "$mirror" in
 	Aliyun)
 		DOWNLOAD_URL="https://mirrors.aliyun.com/docker-ce"
 		;;
-	AzureChinaCloud)
-		DOWNLOAD_URL="https://mirror.azure.cn/docker-ce"
+	Tencent)
+		DOWNLOAD_URL="https://mirrors.tencent.com/docker-ce"
 		;;
 esac
 


### PR DESCRIPTION
AzureChinaCloud's mirror repo is now unreachable , so i changed this one to Tencent's.
The new mirror repo is quite reliable , it's provided by Tencent.

Signed-off-by: D3-3109 <jiose-tze@foxmail.com>