### PR TITLE
Changed the AzureChinaCloud's mirror repo to Tencent's

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -66,8 +66,8 @@ case "$mirror" in
 	Aliyun)
 		DOWNLOAD_URL="https://mirrors.aliyun.com/docker-ce"
 		;;
-	AzureChinaCloud)
-		DOWNLOAD_URL="https://mirror.azure.cn/docker-ce"
+	Tencent)
+		DOWNLOAD_URL="https://mirrors.tencent.com/docker-ce"
 		;;
 esac
 


### PR DESCRIPTION
AzureChinaCloud's mirror repo is now unreachable , so i changed it to Tencent's.
This new mirror repo is quite reliable.
It should be fine this time.

Signed-off-by: D3-3109 <63032814+D3-3109@users.noreply.github.com>