### PR TITLE
fix "REPO_FILE" checks always running, also with "dry run" enabled

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -465,11 +465,6 @@ do_install() {
 				echo "Packages for RHEL are currently only available for s390x."
 				exit 1
 			fi
-			yum_repo="$DOWNLOAD_URL/linux/$lsb_dist/$REPO_FILE"
-			if ! curl -Ifs "$yum_repo" > /dev/null; then
-				echo "Error: Unable to curl repository file $yum_repo, is it valid?"
-				exit 1
-			fi
 			if [ "$lsb_dist" = "fedora" ]; then
 				pkg_manager="dnf"
 				config_manager="dnf config-manager"
@@ -485,12 +480,13 @@ do_install() {
 				pre_reqs="yum-utils"
 				pkg_suffix="el"
 			fi
+			repo_file_url="$DOWNLOAD_URL/linux/$lsb_dist/$REPO_FILE"
 			(
 				if ! is_dry_run; then
 					set -x
 				fi
 				$sh_c "$pkg_manager install -y -q $pre_reqs"
-				$sh_c "$config_manager --add-repo $yum_repo"
+				$sh_c "$config_manager --add-repo $repo_file_url"
 
 				if [ "$CHANNEL" != "stable" ]; then
 					$sh_c "$config_manager $disable_channel_flag docker-ce-*"
@@ -557,8 +553,6 @@ do_install() {
 				echo "Packages for SLES are currently only available for s390x"
 				exit 1
 			fi
-
-			sles_repo="$DOWNLOAD_URL/linux/$lsb_dist/$REPO_FILE"
 			if [ "$dist_version" = "15.3" ]; then
 				sles_version="SLE_15_SP3"
 			else
@@ -566,17 +560,14 @@ do_install() {
 				sles_version="15.$sles_minor_version"
 			fi
 			opensuse_repo="https://download.opensuse.org/repositories/security:SELinux/$sles_version/security:SELinux.repo"
-			if ! curl -Ifs "$sles_repo" > /dev/null; then
-				echo "Error: Unable to curl repository file $sles_repo, is it valid?"
-				exit 1
-			fi
+			repo_file_url="$DOWNLOAD_URL/linux/$lsb_dist/$REPO_FILE"
 			pre_reqs="ca-certificates curl libseccomp2 awk"
 			(
 				if ! is_dry_run; then
 					set -x
 				fi
 				$sh_c "zypper install -y $pre_reqs"
-				$sh_c "zypper addrepo $sles_repo"
+				$sh_c "zypper addrepo $repo_file_url"
 				if ! is_dry_run; then
 						cat >&2 <<-'EOF'
 						WARNING!!


### PR DESCRIPTION
- relates to https://github.com/docker/docker-install/pull/69

These checks were originally added in 3217c543b4c0d54944ec4fb1133510aa8ea06eb7 (https://github.com/docker/docker-install/pull/69),
which added a `REPO_FILE` variable. While it's with good intent to do a check
if the URL is valid, there are some issues with these checks;

The checks depend on `curl`, but are executed _before_ `pre_reqs` are installed,
so will produce an error if `curl` is not found;

    ./install.sh
    # Executing docker install script, commit:
    ./install.sh: line 469: curl: command not found
    Error: Unable to curl repository file https://download.docker.com/linux/fedora/docker-ce.repo, is it valid?

The checks are currently always performed, also if `DRY_RUN=1` is enabled;

    DRY_RUN=1 REPO_FILE=no-such.repo ./install.sh
    # Executing docker install script, commit:
    Error: Unable to curl repository file https://download.docker.com/linux/fedora/no-such.repo, is it valid?

This patch removes the checks to address the above, and to simplify the script.
Running the script will still fail if an invalid URL is used for the `.repo` file,
which fails the script after the `pre_reqs` are installed;

With this patch:

When running the script with `DRY_RUN=1`:

    DRY_RUN=1 ./install.sh
    # Executing docker install script, commit:
    dnf install -y -q dnf-plugins-core
    dnf config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo
    dnf makecache
    dnf install -y -q docker-ce docker-ce-cli containerd.io docker-scan-plugin docker-compose-plugin docker-ce-rootless-extras

When running the script with `DRY_RUN=1` and an invalid repo, the script
completes successfully, but will show the commands it will run, including
the invalid URL:

    DRY_RUN=1 REPO_FILE=no-such.repo ./install.sh
    # Executing docker install script, commit:
    dnf install -y -q dnf-plugins-core
    dnf config-manager --add-repo https://download.docker.com/linux/fedora/no-such.repo
    dnf makecache
    dnf install -y -q docker-ce docker-ce-cli containerd.io docker-scan-plugin docker-compose-plugin docker-ce-rootless-extras

When running the script with an invalid repo URL, it will fail early (after
installing `pre_reqs`:

    REPO_FILE=no-such.repo ./install.sh

    # Executing docker install script, commit:
    + sh -c 'dnf install -y -q dnf-plugins-core'
    ...

    + sh -c 'dnf config-manager --add-repo https://download.docker.com/linux/fedora/no-such.repo'
      Adding repo from: https://download.docker.com/linux/fedora/no-such.repo
      Status code: 404 for https://download.docker.com/linux/fedora/no-such.repo (IP: 65.9.86.56)
      Error: Configuration of repo failed

