### PR TITLE
fix matching of package versions on debian, ubuntu, and raspbian

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -412,7 +412,7 @@ do_install() {
 					echo "# WARNING: VERSION pinning is not supported in DRY_RUN"
 				else
 					# Will work for incomplete versions IE (17.12), but may not actually grab the "latest" if in the test channel
-					pkg_pattern="$(echo "$VERSION" | sed "s/-ce-/~ce~.*/g" | sed "s/-/.*/g").*-0~$lsb_dist"
+					pkg_pattern="$(echo "$VERSION" | sed "s/-ce-/~ce~.*/g" | sed "s/-/.*/g")"
 					search_command="apt-cache madison 'docker-ce' | grep '$pkg_pattern' | head -1 | awk '{\$1=\$1};1' | cut -d' ' -f 3"
 					pkg_version="$($sh_c "$search_command")"
 					echo "INFO: Searching repository for VERSION '$VERSION'"


### PR DESCRIPTION
- relates to https://github.com/docker/docker-ce-packaging/pull/818

The version-format of the packages changed in the docker-ce-packaging repo; https://github.com/docker/docker-ce-packaging/commit/39772a761dfdf810cc23a1ec6084ea3100e6abf0

Which caused the script to fail when specifying a version:

    INFO: Searching repository for VERSION '23.0.0-rc.2'
    INFO: apt-cache madison 'docker-ce' | grep '23.0.0.*rc.2.*-0~debian' | head -1 | awk '{$1=$1};1' | cut -d' ' -f 3

    ERROR: '23.0.0-rc.2' not found amongst apt-cache madison results

Looking at that search, it seemed like it was overly strict;

- matching the distro (debian, ubuntu, or raspbian), which should not be needed, assuming the package repository has been set up correctly (which the script does in earlier steps).
- matching the "0" prefix, which was intended to be used a package-revision (so to allow for packaging-only releases). That part definitely shouldn't be done, as it would not match later revisions (1, 2, 3)

This patch simplifies the matching, and only searches for the package name, and the version specified, which should satisfy the requirement;

    apt-cache madison 'docker-ce' | grep '23.0.0.*rc.2' | head -1 | awk '{$1=$1};1' | cut -d' ' -f 3
    5:23.0.0~rc.2-1~ubuntu.22.04~jammy

    apt-cache madison 'docker-ce-cli' | grep '23.0.0.*rc.2' | head -1 | awk '{$1=$1};1' | cut -d' ' -f 3
    5:23.0.0~rc.2-1~ubuntu.22.04~jammy

With this patch applied, the installation succeeds:

    cat install.sh | DOWNLOAD_URL=https://download-stage.docker.com CHANNEL=test VERSION=23.0.0-rc.2 REPO_FILE=docker-ce-staging.repo sh
    ...
    INFO: Searching repository for VERSION '23.0.0-rc.2'
    INFO: apt-cache madison 'docker-ce' | grep '23.0.0.*rc.2' | head -1 | awk '{$1=$1};1' | cut -d' ' -f 3
    INFO: apt-cache madison 'docker-ce-cli' | grep '23.0.0.*rc.2' | head -1 | awk '{$1=$1};1' | cut -d' ' -f 3
    + sh -c DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends docker-ce=5:23.0.0~rc.2-1~ubuntu.22.04~jammy docker-ce-cli=5:23.0.0~rc.2-1~ubuntu.22.04~jammy containerd.io docker-compose-plugin docker-scan-plugin docker-buildx-plugin >/dev/null

