### PR TITLE
fix: add apparmor-utils to install prereqs

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -389,7 +389,7 @@ do_install() {
 	# Run setup for each distro accordingly
 	case "$lsb_dist" in
 		ubuntu|debian|raspbian)
-			pre_reqs="apt-transport-https ca-certificates curl"
+			pre_reqs="apt-transport-https ca-certificates curl apparmor-utils"
 			if ! command -v gpg > /dev/null; then
 				pre_reqs="$pre_reqs gnupg"
 			fi


### PR DESCRIPTION
Adds apparmor-utils as a prereq dependency

Solves issues for some Debian users on version 23.0
