### PR TITLE
deb: remove --no-install-recommends

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -450,7 +450,7 @@ do_install() {
 				if ! is_dry_run; then
 					set -x
 				fi
-				$sh_c "DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends $pkgs >/dev/null"
+				$sh_c "DEBIAN_FRONTEND=noninteractive apt-get install -y -qq $pkgs >/dev/null"
 				if version_gte "20.10"; then
 					# Install docker-ce-rootless-extras without "--no-install-recommends", so as to install slirp4netns when available
 					$sh_c "DEBIAN_FRONTEND=noninteractive apt-get install -y -qq docker-ce-rootless-extras${pkg_version%=} >/dev/null"


### PR DESCRIPTION
- supersedes, closes https://github.com/docker/docker-install/pull/333
- relates to https://github.com/docker/docker-install/pull/44
- relates to https://github.com/moby/moby/issues/44900


The installation for deb packages used a `--no-install-recommends` to skip "recommended" packages. This flag was added in ab5553e3027fdf53c5b68ef543f7437dc15c33df (https://github.com/docker/docker-install/pull/44) to work around an issue on Ubuntu 17.10 (which had aufs-tools as recommended dependency), causing the kernel to be updated.

While "recommended" packages _can_ be omitted during installation, they are a "strong" recommendation, and should really be installed by default:

> Recommends
>
> This declares a strong, but not absolute, dependency.
> The Recommends field should list packages that would be found together
> with this one in all but unusual installations.

Including the `--no-install-recommends` option could result in `apparmor_parser` binary (part of the `apparmor` package) to be missing, which would cause the daemon failing to start on systems with AppArmor support enabled:

    Error response from daemon: AppArmor enabled on system but the docker-default profile could not be loaded: running `apparmor_parser apparmor_parser --version` failed with output:
    error: exec: "apparmor_parser": executable file not found in $PATH
    Error: failed to start containers: somecontainer

This patch removes the `--no-install-recommends` so that the recommended packages are installed.
