### PR TITLE
SLES: remove unused rootless_pkg_version

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -599,10 +599,6 @@ do_install() {
 					# It's okay for cli_pkg_version to be blank, since older versions don't support a cli package
 					cli_pkg_version="$($sh_c "$search_command")"
 					pkg_version="-$pkg_version"
-
-					search_command="zypper search -s --match-exact 'docker-ce-rootless-extras' | grep '$pkg_pattern' | tail -1 | awk '{print \$6}'"
-					rootless_pkg_version="$($sh_c "$search_command")"
-					rootless_pkg_version="-$rootless_pkg_version"
 				fi
 			fi
 			(


### PR DESCRIPTION
- relates to https://github.com/docker/docker-install/pull/248
- relates to https://github.com/docker/docker-install/pull/287


This variable was introduced in 63fb2060c9436bb3ad4434bdbf55f92824428e8e (https://github.com/docker/docker-install/pull/248), but was later refactored in ab0389264936174e064d0fcf3ab39d2ee8d9b976 (https://github.com/docker/docker-install/pull/287) aligned the installation steps for SLES with the other distros (using the version of the "docker-ce" package itself, as those versions always match).

This patch removes the unused `rootless_pkg_version` variable, and the code to resolve that version.
