### PR TITLE
Fix installation on debian testing (bookworm) (carry 327)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -244,6 +244,9 @@ check_forked() {
 				fi
 				dist_version="$(sed 's/\/.*//' /etc/debian_version | sed 's/\..*//')"
 				case "$dist_version" in
+					12)
+						dist_version="bookworm"
+					;;
 					11)
 						dist_version="bullseye"
 					;;
@@ -332,6 +335,9 @@ do_install() {
 		debian|raspbian)
 			dist_version="$(sed 's/\/.*//' /etc/debian_version | sed 's/\..*//')"
 			case "$dist_version" in
+				12)
+					dist_version="bookworm"
+				;;
 				11)
 					dist_version="bullseye"
 				;;


### PR DESCRIPTION
- carries https://github.com/docker/docker-install/pull/327
- closes https://github.com/docker/docker-install/pull/327


We published packages now for Debian 12 (bookworm) for testing, so we can
update this to use the correct version;
https://download.docker.com/linux/debian/dists/bookworm/pool/stable/amd64/