### PR TITLE
print deprecation warning for Fedora 35 and before

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -380,7 +380,7 @@ do_install() {
 			deprecation_notice "$lsb_dist" "$dist_version"
 			;;
 		fedora.*)
-			if [ "$dist_version" -lt 33 ]; then
+			if [ "$dist_version" -lt 36 ]; then
 				deprecation_notice "$lsb_dist" "$dist_version"
 			fi
 			;;


### PR DESCRIPTION
Fedora 35 reached EOL on December 13, 2022, and we're no longer building new packages for it;;

https://docs.fedoraproject.org/en-US/releases/eol/
