### PR TITLE
gha: update distros and version to install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,12 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu:18.04
+          - ubuntu:20.04
+          - ubuntu:22.04
           - centos:7
+          - quay.io/centos/centos:stream9
         version:
-          - 19.03
+          - "20.10"
           - ""
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
           - ""
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Shellcheck
       run: make shellcheck
     - name: Check distribution

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TEST_IMAGE?=ubuntu:18.04
+TEST_IMAGE?=ubuntu:22.04
 VERSION?=
 CHANNEL?=
 


### PR DESCRIPTION
- updating the "version" to install to 20.10 (previous version)
- remove ubuntu 18.04, as it's EOL soon
- add last 2 LTS versions of Ubuntu
- add centos:9 (stream)


Also updated to actions/checkout@v3