### PR TITLE
remove redundant install for scan-cli-plugin

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -443,10 +443,6 @@ do_install() {
 						# older versions didn't ship the cli and containerd as separate packages
 						pkgs="$pkgs docker-ce-cli${cli_pkg_version%=} containerd.io"
 				fi
-				if version_gte "20.10" && [ "$(uname -m)" = "x86_64" ]; then
-						# also install the latest version of the "docker scan" cli-plugin (only supported on x86 currently)
-						pkgs="$pkgs docker-scan-plugin"
-				fi
 				if version_gte "20.10"; then
 						pkgs="$pkgs docker-compose-plugin docker-ce-rootless-extras$pkg_version"
 				fi
@@ -529,10 +525,6 @@ do_install() {
 					else
 						pkgs="$pkgs docker-ce-cli containerd.io"
 					fi
-				fi
-				if version_gte "20.10" && [ "$(uname -m)" = "x86_64" ]; then
-						# also install the latest version of the "docker scan" cli-plugin (only supported on x86 currently)
-						pkgs="$pkgs docker-scan-plugin"
 				fi
 				if version_gte "20.10"; then
 					pkgs="$pkgs docker-compose-plugin docker-ce-rootless-extras$pkg_version"


### PR DESCRIPTION
This explict install was added because docker 20.10 did not have an explicit dependency on the plugin. The current release of the Docker CLI (23.0) already has a "Recommends:" dependency on the plugin, and 0095742fb5d923f876e720731073c541f47f0f79 (https://github.com/docker/docker-install/pull/335) removed the "--no-install-recommends", so fresh installs of Docker 23.0 will already install this plugin through that dependency.

Removing the explicit install, because the scan-cli-plugin has been deprecated, and will no longer receive updates, so we don't want it to be installed for the upcoming 24.0 release when using this script. see; https://github.com/docker/scan-cli-plugin/blob/b69ac460a6c23243b858326f0e26f6bd202ca781/internal/deprecation.go#L13-L15 (https://github.com/docker/scan-cli-plugin/pull/225)