### PR TITLE
gha: temporarily disable CentOS 9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,8 @@ jobs:
           - ubuntu:20.04
           - ubuntu:22.04
           - centos:7
-          - quay.io/centos/centos:stream9
+# FIXME(thaJeztah): re-enable once CentOS 9 package repositories are fixed.
+#          - quay.io/centos/centos:stream9
         version:
           - "20.10"
           - ""


### PR DESCRIPTION
Looks like their package repositories are having a bad day, or changes were made (again);

    # Executing docker install script, commit: 60327925bf2a9c6f81084661b0c05edc8263a3c9
    + sh -c 'yum install -y -q yum-utils'
    Error: Failed to download metadata for repo 'baseos': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried