### PR TITLE
Revert "gha: temporarily disable CentOS 9"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,7 @@ jobs:
           - ubuntu:20.04
           - ubuntu:22.04
           - centos:7
-# FIXME(thaJeztah): re-enable once CentOS 9 package repositories are fixed.
-#          - quay.io/centos/centos:stream9
+          - quay.io/centos/centos:stream9
         version:
           - "20.10"
           - ""


### PR DESCRIPTION
- This reverts commit c435f9da96d0e5ff3bf0ec32bf2567fd823ff389 (https://github.com/docker/docker-install/pull/352).