### PR TITLE
Introduce the CentOS 7 image from Quay.io repository

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
         os:
           - ubuntu:20.04
           - ubuntu:22.04
-          - centos:7
+          - quay.io/centos/centos:centos7
           - quay.io/centos/centos:stream9
         version:
           - "20.10"


### PR DESCRIPTION
Introduce the CentOS 7 image from [Quay.io repository](https://quay.io/repository/centos/centos?tab=tags&tag=latest).

Based on [Docker Hub - CentOS](https://hub.docker.com/_/centos/tags), there is no official support anymore.

This PR redefine the image repo. for CentOS 7, in that way the CI file (`ci.yml`) will be more consistent (images from the same repo) at the CentOS context.
