### PR TITLE
Deprecate the nightly channel

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -89,7 +89,7 @@ VERSION="${VERSION#v}"
 #   * stable
 #   * test
 #   * edge (deprecated)
-#   * nightly (unmaintained)
+#   * nightly (deprecated)
 DEFAULT_CHANNEL_VALUE="stable"
 if [ -z "$CHANNEL" ]; then
 	CHANNEL=$DEFAULT_CHANNEL_VALUE
@@ -150,7 +150,7 @@ case "$CHANNEL" in
 	stable|test)
 		;;
 	edge|nightly)
-		>&2 echo "DEPRECATED: the $CHANNEL channel has been deprecated and no longer supported by this script."
+		>&2 echo "DEPRECATED: the $CHANNEL channel has been deprecated and is no longer supported by this script."
 		exit 1
 		;;
 	*)

--- a/rootless-install.sh
+++ b/rootless-install.sh
@@ -21,9 +21,9 @@ SCRIPT_COMMIT_SHA=UNKNOWN
 # This script should be run with an unprivileged user and install/setup Docker under $HOME/bin/.
 
 # The channel to install from:
-#   * nightly
 #   * test
 #   * stable
+#   * nightly (deprecated)
 DEFAULT_CHANNEL_VALUE="stable"
 if [ -z "$CHANNEL" ]; then
 	CHANNEL=$DEFAULT_CHANNEL_VALUE
@@ -45,12 +45,10 @@ case "$CHANNEL" in
         STATIC_RELEASE_ROOTLESS_URL="https://download.docker.com/linux/static/$CHANNEL/$(uname -m)/docker-rootless-extras-${TEST_LATEST}.tgz"
         ;;
     "nightly")
-        echo "# Installing nightly"
-        STATIC_RELEASE_URL="https://master.dockerproject.org/linux/$(uname -m)/docker.tgz"
-        STATIC_RELEASE_ROOTLESS_URL="https://master.dockerproject.org/linux/$(uname -m)/docker-rootless-extras.tgz"
+        >&2 echo "DEPRECATED: the nightly channel has been deprecated and is no longer supported by this script."; exit 1
         ;;
     *)
-        >&2 echo "Aborting because of unknown CHANNEL \"$CHANNEL\". Set \$CHANNEL to either \"stable\", \"test\", or \"nightly\"."; exit 1
+        >&2 echo "Aborting because of unknown CHANNEL \"$CHANNEL\". Set \$CHANNEL to either \"stable\" or \"test\"."; exit 1
         ;;
 esac
 


### PR DESCRIPTION
I noticed a discrepancy in the main install script where nightly was marked as unmaintained in a comment but it was also flagged as deprecated in the warning message.

I brought this up with @thaJeztah on Slack and he mentioned he thinks it's ok to officially deprecate the nightly channel.

When I searched this repo for references to nightly I also found a reference to it in the rootless-install script. We didn't discuss that on Slack but I did set things up to deprecate it there as well. I used a similar pattern to what's in the main install script.