### PR TITLE
Update rootless-install.sh with 25.0.0-beta.1

### DIFF
--- a/rootless-install.sh
+++ b/rootless-install.sh
@@ -30,7 +30,7 @@ if [ -z "$CHANNEL" ]; then
 fi
 # The latest release is currently hard-coded.
 STABLE_LATEST="24.0.7"
-TEST_LATEST="24.0.7"
+TEST_LATEST="25.0.0-beta.1"
 STATIC_RELEASE_URL=
 STATIC_RELEASE_ROOTLESS_URL=
 case "$CHANNEL" in


### PR DESCRIPTION
25.0.0-beta.1 is now available via the test channel.