### PR TITLE
Added a hint for a very usual post install step

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -301,7 +301,12 @@ echo_docker_as_nonroot() {
 	echo "         documentation for details: https://docs.docker.com/go/attack-surface/"
 	echo
 	echo "================================================================================"
-	echo
+	echo 
+	echo "Hint: You might want to grant Docker access to the current user by executing:"
+	echo 
+	echo '         sudo usermod -aG docker $USER'
+	echo 
+	echo "================================================================================"
 }
 
 # Check if this is a forked Linux distro


### PR DESCRIPTION
I would like to add a hint for post install steps as I'm unable to remember the exact command and I'm always googling that command after using the install script.

I believe that it will be very useful for everyone to mention the exact command for giving permissions to the current user to use the docker daemon.