### PR TITLE
update script to use .asc, remove gpg as pre-requisite

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -496,10 +496,7 @@ do_install() {
 	case "$lsb_dist" in
 		ubuntu|debian|raspbian)
 			pre_reqs="apt-transport-https ca-certificates curl"
-			if ! command -v gpg > /dev/null; then
-				pre_reqs="$pre_reqs gnupg"
-			fi
-			apt_repo="deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] $DOWNLOAD_URL/linux/$lsb_dist $dist_version $CHANNEL"
+			apt_repo="deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] $DOWNLOAD_URL/linux/$lsb_dist $dist_version $CHANNEL"
 			(
 				if ! is_dry_run; then
 					set -x
@@ -507,8 +504,8 @@ do_install() {
 				$sh_c 'apt-get update -qq >/dev/null'
 				$sh_c "DEBIAN_FRONTEND=noninteractive apt-get install -y -qq $pre_reqs >/dev/null"
 				$sh_c 'install -m 0755 -d /etc/apt/keyrings'
-				$sh_c "curl -fsSL \"$DOWNLOAD_URL/linux/$lsb_dist/gpg\" | gpg --dearmor --yes -o /etc/apt/keyrings/docker.gpg"
-				$sh_c "chmod a+r /etc/apt/keyrings/docker.gpg"
+				$sh_c "curl -fsSL \"$DOWNLOAD_URL/linux/$lsb_dist/gpg\" -o /etc/apt/keyrings/docker.asc"
+				$sh_c "chmod a+r /etc/apt/keyrings/docker.asc"
 				$sh_c "echo \"$apt_repo\" > /etc/apt/sources.list.d/docker.list"
 				$sh_c 'apt-get update -qq >/dev/null'
 			)


### PR DESCRIPTION
- relates to https://github.com/docker/docs/pull/19138

Current distro versions now allow the GPG key to be stored as an `.asc` file, which simplifies installation. Changing the file extension for the GPG key to .asc lets apt-get know the GPG key is in ASCII armor format, in which case there is no need to "dearmor", and we no longer need gpg as a pre-requisite. Instructions for manual installation on Debian based distros were updated in our documentation through [docker/docs@33befd6].

It's common for users to install packages in a combination of the convenience script and manual (e.g. to update the packages after install, or vice-versa). Given that both the script and the manual steps configure the repository, we want those steps to align, otherwise (potentially?) warnings / errors may occur;

    $ sudo apt-get update
    E: Conflicting values set for option Signed-By regarding source https://download.docker.com/linux/debian/ bullseye: /usr/share/keyrings/docker-ce-archive-keyring.gpg != /usr/share/keyrings/docker-archive-keyring.gpg
    E: The list of sources could not be read.

In either case; let's make sure that our script aligns with the manual steps that we document.

[docker/docs@33befd6]: https://github.com/docker/docs/commit/33befd692249d11ce7bc88052d82709a07a8107f