### PR TITLE
gha: remove CentOS 7 (EOL), add Ubuntu 24.04, use engine 26.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
         os:
           - ubuntu:20.04
           - ubuntu:22.04
-          - centos:7
+          - ubuntu:24.04
           - quay.io/centos/centos:stream9
         version:
-          - "20.10"
+          - "26.1"
           - ""
 
     steps:


### PR DESCRIPTION
- relates to https://github.com/docker/runtime-team/issues/119
- relates to https://github.com/docker/docker-install/pull/426#issuecomment-2199735994
---

- CentOS 7 reached EOL
- Adding Ubuntu 24.04 (LTS)
- Update the "old" engine version to install to 26.1

