### PR TITLE
remove code to handle nightly and edge channels

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -88,8 +88,6 @@ VERSION="${VERSION#v}"
 # The channel to install from:
 #   * stable
 #   * test
-#   * edge (deprecated)
-#   * nightly (deprecated)
 DEFAULT_CHANNEL_VALUE="stable"
 if [ -z "$CHANNEL" ]; then
 	CHANNEL=$DEFAULT_CHANNEL_VALUE
@@ -148,10 +146,6 @@ esac
 
 case "$CHANNEL" in
 	stable|test)
-		;;
-	edge|nightly)
-		>&2 echo "DEPRECATED: the $CHANNEL channel has been deprecated and is no longer supported by this script."
-		exit 1
 		;;
 	*)
 		>&2 echo "unknown CHANNEL '$CHANNEL': use either stable or test."

--- a/rootless-install.sh
+++ b/rootless-install.sh
@@ -26,7 +26,6 @@ STABLE_LATEST="27.0.3"
 # The channel to install from:
 #   * test
 #   * stable
-#   * nightly (deprecated)
 DEFAULT_CHANNEL_VALUE="stable"
 if [ -z "$CHANNEL" ]; then
 	CHANNEL=$DEFAULT_CHANNEL_VALUE
@@ -48,11 +47,9 @@ case "$CHANNEL" in
         STATIC_RELEASE_URL="https://download.docker.com/linux/static/$CHANNEL/$(uname -m)/docker-${TEST_LATEST}.tgz"
         STATIC_RELEASE_ROOTLESS_URL="https://download.docker.com/linux/static/$CHANNEL/$(uname -m)/docker-rootless-extras-${TEST_LATEST}.tgz"
         ;;
-    "nightly")
-        >&2 echo "DEPRECATED: the nightly channel has been deprecated and is no longer supported by this script."; exit 1
-        ;;
     *)
-        >&2 echo "Aborting because of unknown CHANNEL \"$CHANNEL\". Set \$CHANNEL to either \"stable\" or \"test\"."; exit 1
+        >&2 echo "Aborting because of unknown CHANNEL \"$CHANNEL\". Set \$CHANNEL to either \"stable\" or \"test\"."
+        exit 1
         ;;
 esac
 


### PR DESCRIPTION
Thse channels have been deprecated for quite a while, and the script has produced an error for them for a long time, so nobody using this script can depend on it being there.


