### PR TITLE
add deprecation warning for CentOS 7 / RHEL 7

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -473,6 +473,9 @@ do_install() {
 	# Print deprecation warnings for distro versions that recently reached EOL,
 	# but may still be commonly used (especially LTS versions).
 	case "$lsb_dist.$dist_version" in
+		centos.7|rhel.7)
+			deprecation_notice "$lsb_dist" "$dist_version"
+			;;
 		debian.stretch|debian.jessie)
 			deprecation_notice "$lsb_dist" "$dist_version"
 			;;


### PR DESCRIPTION
- relates to https://github.com/docker/runtime-team/issues/119
- relates to https://github.com/docker/docker-install/pull/427

With this patch:

```bash
sh -c install.sh
# Executing docker install script, commit:

DEPRECATION WARNING
    This Linux distribution (centos 7) reached end-of-life and is no longer supported by this script.
    No updates or security fixes will be released for this distribution, and users are recommended
    to upgrade to a currently maintained version of centos.

Press Ctrl+C now to abort this script, or wait for the installation to continue.
```
