### PR TITLE
add deprecation warnings for Ubuntu 18.04 (bionic), Debian, Raspbian 10 Buster, Fedora <= 38, and CentOS (Stream) 8

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -467,7 +467,7 @@ do_install() {
 	# Print deprecation warnings for distro versions that recently reached EOL,
 	# but may still be commonly used (especially LTS versions).
 	case "$lsb_dist.$dist_version" in
-		centos.7|rhel.7)
+		centos.8|centos.7|rhel.7)
 			deprecation_notice "$lsb_dist" "$dist_version"
 			;;
 		debian.buster|debian.stretch|debian.jessie)

--- a/install.sh
+++ b/install.sh
@@ -483,7 +483,7 @@ do_install() {
 			deprecation_notice "$lsb_dist" "$dist_version"
 			;;
 		fedora.*)
-			if [ "$dist_version" -lt 36 ]; then
+			if [ "$dist_version" -lt 39 ]; then
 				deprecation_notice "$lsb_dist" "$dist_version"
 			fi
 			;;

--- a/install.sh
+++ b/install.sh
@@ -476,7 +476,7 @@ do_install() {
 		raspbian.stretch|raspbian.jessie)
 			deprecation_notice "$lsb_dist" "$dist_version"
 			;;
-		ubuntu.xenial|ubuntu.trusty)
+		ubuntu.bionic|ubuntu.xenial|ubuntu.trusty)
 			deprecation_notice "$lsb_dist" "$dist_version"
 			;;
 		ubuntu.lunar|ubuntu.kinetic|ubuntu.impish|ubuntu.hirsute|ubuntu.groovy|ubuntu.eoan|ubuntu.disco|ubuntu.cosmic)

--- a/install.sh
+++ b/install.sh
@@ -470,10 +470,10 @@ do_install() {
 		centos.7|rhel.7)
 			deprecation_notice "$lsb_dist" "$dist_version"
 			;;
-		debian.stretch|debian.jessie)
+		debian.buster|debian.stretch|debian.jessie)
 			deprecation_notice "$lsb_dist" "$dist_version"
 			;;
-		raspbian.stretch|raspbian.jessie)
+		raspbian.buster|raspbian.stretch|raspbian.jessie)
 			deprecation_notice "$lsb_dist" "$dist_version"
 			;;
 		ubuntu.bionic|ubuntu.xenial|ubuntu.trusty)


### PR DESCRIPTION
### add deprecation warning for Ubuntu Bionic 18.04 LTS

Ubuntu 18.04 LTS reached end of standard support. Expanded Security Maintenance
(ESM) is available, but requires a subscription, and we don't provide packages
for those.

- https://wiki.ubuntu.com/Releases
- https://ubuntu.com//blog/18-04-end-of-standard-support


### add deprecation warning for Debian, Raspbian 10 Buster (EOL LTS: 2024-06-30)

Debian 10 reached EOL and we're no longer building packages for it.


### add deprecation warning for Fedora 38 and older

Fedora 38 and older reached EOL



### add deprecation warning for CentOS (Stream) 8 (EOL: 2024-05-31)

CentOS 8 stream reached EOL, and we're no longer building packages for it.
