### PR TITLE
remove check for RHEL only being available on s390x

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -552,11 +552,6 @@ do_install() {
 			exit 0
 			;;
 		centos|fedora|rhel)
-			if [ "$(uname -m)" != "s390x" ] && [ "$lsb_dist" = "rhel" ]; then
-				echo "Packages for RHEL are currently only available for s390x."
-				exit 1
-			fi
-
 			if command_exists dnf; then
 				pkg_manager="dnf"
 				pkg_manager_flags="--best"


### PR DESCRIPTION
relates to:

- https://docker.atlassian.net/browse/POS-1687
- https://github.com/docker/docs/pull/20174
- https://github.com/docker/docker-install/pull/248



This check was added in 63fb2060c9436bb3ad4434bdbf55f92824428e8e (https://github.com/docker/docker-install/pull/239 / https://github.com/docker/docker-install/pull/248), at which time we did not provide packages fro RHEL on architectures other than s390x.

We now provide packages for RHEL 8 and 9 for amd64 (x86), arm64, and s390x, so we can remove this check.

Note that we do not (yet?) provide packages for ppc64le, but this is more of a niche use-case, so not adding a special condition for that, as we don't provide that check for other distros.

