### PR TITLE
use double-quotes to make output more readable

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -569,8 +569,8 @@ do_install() {
 					$sh_c "rm -f '${TMP_REPO_FILE}'"
 
 					if [ "$CHANNEL" != "stable" ]; then
-						$sh_c "dnf5 config-manager setopt 'docker-ce-*.enabled=0'"
-						$sh_c "dnf5 config-manager setopt 'docker-ce-$CHANNEL.enabled=1'"
+						$sh_c "dnf5 config-manager setopt \"docker-ce-*.enabled=0\""
+						$sh_c "dnf5 config-manager setopt \"docker-ce-$CHANNEL.enabled=1\""
 					fi
 					$sh_c "dnf makecache"
 				elif command_exists dnf; then
@@ -578,8 +578,8 @@ do_install() {
 					$sh_c "dnf config-manager --add-repo $repo_file_url"
 
 					if [ "$CHANNEL" != "stable" ]; then
-						$sh_c "dnf config-manager --set-disabled 'docker-ce-*'"
-						$sh_c "dnf config-manager --set-enabled 'docker-ce-$CHANNEL'"
+						$sh_c "dnf config-manager --set-disabled \"docker-ce-*\""
+						$sh_c "dnf config-manager --set-enabled \"docker-ce-$CHANNEL\""
 					fi
 					$sh_c "dnf makecache"
 				else
@@ -587,8 +587,8 @@ do_install() {
 					$sh_c "yum config-manager --add-repo $repo_file_url"
 
 					if [ "$CHANNEL" != "stable" ]; then
-						$sh_c "yum config-manager --disable 'docker-ce-*'"
-						$sh_c "yum config-manager --enable 'docker-ce-$CHANNEL'"
+						$sh_c "yum config-manager --disable \"docker-ce-*\""
+						$sh_c "yum config-manager --enable \"docker-ce-$CHANNEL\""
 					fi
 					$sh_c "yum makecache"
 				fi


### PR DESCRIPTION
- updates https://github.com/docker/docker-install/pull/359


commit 766b70c5be1a000e09a159aedd0d2375dee84ded quoted these values to prevent globbing, but used single quotes. However, these commands are executed with `sh -c` using single quotes, which makes the output hard to read because of the embedded quotes being escaped.

This patch changes to use double-quotes, which should still prevent globbing to happen, but make the output more readable.

Before:

    CHANNEL=test ./install.sh
    ...
    Adding repo from: https://download.docker.com/linux/centos/docker-ce.repo
    + '[' test '!=' stable ']'
    + sh -c 'dnf config-manager --set-disabled '\''docker-ce-*'\'''
    + sh -c 'dnf config-manager --set-enabled '\''docker-ce-test'\'''
    + sh -c 'dnf makecache'

After:

    CHANNEL=test ./install.sh
    ...
    Adding repo from: https://download.docker.com/linux/centos/docker-ce.repo
    + '[' test '!=' stable ']'
    + sh -c 'dnf config-manager --set-disabled "docker-ce-*"'
    + sh -c 'dnf config-manager --set-enabled "docker-ce-test"'
    + sh -c 'dnf makecache'


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

