### PR TITLE
Skip sleep and warning of 'command_exists docker' when relevant flag is set

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -359,7 +359,7 @@ check_forked() {
 do_install() {
 	echo "# Executing docker install script, commit: $SCRIPT_COMMIT_SHA"
 
-	if command_exists docker; then
+	if [ -z "$SKIP_DOCKER_EXISTS_WARN" ] && command_exists docker; then
 		cat >&2 <<-'EOF'
 			Warning: the "docker" command appears to already exist on this system.
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

Closes #183 

**- What I did**
Added the ability to skip sleep related to `command_exists docker` check.

**- How I did it**
Added a relevant flag that skips block of code when it is present. Previous/Default functionality is not affected.

**- How to verify it**
Run `SKIP_DOCKER_EXISTS_WARN=true ./install.sh` vs `./install.sh` to verify relevant warning and sleep time do not appear/occur.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Skip sleep and warning of 'command_exists docker' when `SKIP_DOCKER_EXISTS_WARN` is set

**- A picture of a cute animal (not mandatory but encouraged)**