### PR TITLE
install: Default to staging repo file for staging download URL

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -101,6 +101,11 @@ fi
 DEFAULT_REPO_FILE="docker-ce.repo"
 if [ -z "$REPO_FILE" ]; then
 	REPO_FILE="$DEFAULT_REPO_FILE"
+	# Automatically default to a staging repo fora
+	# a staging download url (download-stage.docker.com)
+	case "$DOWNLOAD_URL" in
+		*-stage*) REPO_FILE="docker-ce-staging.repo";;
+	esac
 fi
 
 mirror=''


### PR DESCRIPTION
When using a staging download URL (containing "-stage" in the URL), and no explicit repo was provided automatically use the staging repo file as well.

(This only affects DNF distros)

So it's sufficient to do:

```
curl -L get.docker.com | DOWNLOAD_URL="https://download-stage.docker.com" sh -
```

instead of
```
curl -L get.docker.com | REPO_FILE="docker-ce-staging.repo" DOWNLOAD_URL="https://download-stage.docker.com" sh -
```

Signed-off-by: Paweł Gronowski <pawel.gronowski@docker.com>