### PR TITLE
rootless: revert 28.1.0 from stable

### DIFF
--- a/rootless-install.sh
+++ b/rootless-install.sh
@@ -21,7 +21,7 @@ SCRIPT_COMMIT_SHA=UNKNOWN
 # This script should be run with an unprivileged user and install/setup Docker under $HOME/bin/.
 
 # latest version available in the stable channel.
-STABLE_LATEST="28.1.0"
+STABLE_LATEST="28.0.4"
 
 # latest version available in the test channel.
 TEST_LATEST="28.1.0"


### PR DESCRIPTION
Due to regression in the dockerd-rootless.sh script: https://github.com/moby/moby/pull/49727#discussion_r2049365900