### PR TITLE
rootless: update test version to 28.2.0-rc.1

### DIFF
--- a/rootless-install.sh
+++ b/rootless-install.sh
@@ -24,7 +24,7 @@ SCRIPT_COMMIT_SHA=UNKNOWN
 STABLE_LATEST="28.1.1"
 
 # latest version available in the test channel.
-TEST_LATEST="28.1.1"
+TEST_LATEST="28.2.0-rc.1"
 
 # The channel to install from:
 #   * test


### PR DESCRIPTION
Signed-off-by: Paweł Gronowski <pawel.gronowski@docker.com>