### PR TITLE
add ubuntu 20.04 "focal" (LTS) to list of EOL distros, use docker 27.5 for versioned install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,12 +9,11 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu:20.04
           - ubuntu:22.04
           - ubuntu:24.04
           - quay.io/centos/centos:stream9
         version:
-          - "26.1"
+          - "27.5"
           - ""
 
     steps:

--- a/install.sh
+++ b/install.sh
@@ -489,7 +489,7 @@ do_install() {
 		raspbian.buster|raspbian.stretch|raspbian.jessie)
 			deprecation_notice "$lsb_dist" "$dist_version"
 			;;
-		ubuntu.bionic|ubuntu.xenial|ubuntu.trusty)
+		ubuntu.focal|ubuntu.bionic|ubuntu.xenial|ubuntu.trusty)
 			deprecation_notice "$lsb_dist" "$dist_version"
 			;;
 		ubuntu.mantic|ubuntu.lunar|ubuntu.kinetic|ubuntu.impish|ubuntu.hirsute|ubuntu.groovy|ubuntu.eoan|ubuntu.disco|ubuntu.cosmic)


### PR DESCRIPTION
Ubuntu 20.04 reached end of support on April 30. There's still commercial ESM (Extended Security Maintenance) support, but we don't account for that in our packages; https://ubuntu.com/blog/ubuntu-20-04-eol-for-devicesional


**- A picture of a cute animal (not mandatory but encouraged)**

