### PR TITLE
Avoid installing missing packages for version 23 (and moving them to 28.2)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -554,7 +554,10 @@ do_install() {
 						pkgs="$pkgs docker-compose-plugin docker-ce-rootless-extras$pkg_version"
 				fi
 				if version_gte "23.0"; then
-						pkgs="$pkgs docker-buildx-plugin docker-model-plugin"
+						pkgs="$pkgs docker-buildx-plugin"
+				fi
+				if version_gte "28.2"; then
+						pkgs="$pkgs docker-model-plugin"
 				fi
 				if ! is_dry_run; then
 					set -x


### PR DESCRIPTION
On ubuntu bionic and some other debian/versions, the docker-model-plugin package is missing. The suggestion was to just install the package named docker-buildx-plugin in the version 23 check, while moving the missing package docker-model-plugin to a new "version 28.2" check.

See: https://github.com/docker/docker-install/issues/509