### PR TITLE
gha: Fix stdin tty attach failing the deploy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ AWS?=docker run \
 	-e AWS_ACCESS_KEY_ID \
 	-e AWS_SECRET_ACCESS_KEY \
 	-e AWS_SESSION_TOKEN \
-	--rm -it amazon/aws-cli
+	--rm amazon/aws-cli
 
 .PHONY: deploy
 deploy: build/$(CHANNEL)/install.sh build/$(CHANNEL)/rootless-install.sh


### PR DESCRIPTION
Fixes `the input device is not a TTY`