### PR TITLE
feat: remove script post install

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,14 @@ From `https://get.docker.com`:
 ```shell
 curl -fsSL https://get.docker.com -o get-docker.sh
 sh get-docker.sh
+rm get-docker.sh
 ```
 
 From `https://test.docker.com`:
 ```shell
 curl -fsSL https://test.docker.com -o test-docker.sh
 sh test-docker.sh
+rm get-docker.sh
 ```
 
 From the source repo (This will install latest from the `stable` channel):


### PR DESCRIPTION
I have updated README.md by adding the command to remove get-docker.sh script after the installation