### PR TITLE
Move RHEL <10 .repo files to their own directory

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -573,6 +573,9 @@ do_install() {
 				exit 1
 			fi
 			repo_file_url="$DOWNLOAD_URL/linux/$lsb_dist/$REPO_FILE"
+			if [ "$dist_version" -lt 10 ]; then
+				repo_file_url="$DOWNLOAD_URL/linux/$lsb_dist/$dist_version/$REPO_FILE"
+			fi
 			(
 				if ! is_dry_run; then
 					set -x


### PR DESCRIPTION
.repo files for RHEL 8 and 9 are moved to their directories and the top-level .repo now uses $releasever_major to point to the correct baseurl.

DRAFT: Needs actual changes in the release-repo