### PR TITLE
Makefile/test: Fix failure not being propagated

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ test: $(foreach channel,$(CHANNELS),build/$(channel)/install.sh)
 			-e VERSION \
 			-e CHANNEL \
 			$(TEST_IMAGE) \
-			sh $$file) | tail -n 30; \
+			sh $$file) || exit $$?; \
 	done
 
 AWS?=docker run \


### PR DESCRIPTION
Running in subshell doesn't automatically propagate its exit code to the parent shell (even with `set -e`).

This made the `make test` command NOT exit with a non-zero exit code if the test actually failed.

Also drop `tail` call because it's actually better to have the full trace.