### PR TITLE
rootless: Automatically populate TEST/STABLE version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,12 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Shellcheck
+      env:
+        GH_TOKEN: ${{ github.token }}
       run: make shellcheck
     - name: Check distribution
+      env:
+        GH_TOKEN: ${{ github.token }}
       run: TEST_IMAGE=${{ matrix.os }} VERSION=${{ matrix.version }} make test
 
   # This is a separate workflow step, because we need to check it outside of container (due to lsmod, iptables checks)
@@ -30,7 +34,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install rootless
+      env:
+        GH_TOKEN: ${{ github.token }}
       run: |
         sudo sh -c 'echo 0 > /proc/sys/kernel/apparmor_restrict_unprivileged_userns'
-        FORCE_ROOTLESS_INSTALL=1 ./rootless-install.sh
+        make build/test/rootless-install.sh
+        FORCE_ROOTLESS_INSTALL=1 ./build/test/rootless-install.sh
     

--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -12,10 +12,14 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Diff stable
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
             make CHANNEL=stable diff
 
       - name: Diff test
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
             make CHANNEL=test diff
 

--- a/rootless-install.sh
+++ b/rootless-install.sh
@@ -21,10 +21,10 @@ SCRIPT_COMMIT_SHA="$LOAD_SCRIPT_COMMIT_SHA"
 # This script should be run with an unprivileged user and install/setup Docker under $HOME/bin/.
 
 # latest version available in the stable channel.
-STABLE_LATEST="28.5.2"
+STABLE_LATEST="$LOAD_SCRIPT_STABLE_LATEST"
 
 # latest version available in the test channel.
-TEST_LATEST="29.0.0-rc.2"
+TEST_LATEST="$LOAD_SCRIPT_TEST_LATEST"
 
 # The channel to install from:
 #   * test

--- a/scripts/get-version.sh
+++ b/scripts/get-version.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -e
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <stable|test>" >&2
+    exit 1
+fi
+
+channel="$1"
+
+last_release_tag() {
+    local field="$1"
+    gh -R moby/moby release list -O desc --json tagName,isLatest,isPrerelease \
+        -q ".[] | select(.${field}) | \
+            .tagName | \
+            sub(\"^docker-\"; \"\") | \
+            select(startswith(\"v\") == true) | \
+            sub(\"^v\"; \"\")" |
+        head -n1
+}
+
+case "$channel" in
+    stable) last_release_tag 'isLatest' ;;
+    test) last_release_tag 'isPrerelease' ;;
+    *)
+        echo "Error: Invalid channel '$channel'. Use 'stable' or 'test'." >&2
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
When building the final install.sh script - fill the latest versions based on Github releases.

With this we no longer need to manually the rootless versions via PRs like this: https://github.com/docker/docker-install/pull/531