### PR TITLE
Fix installation on debian testing (forky)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -391,7 +391,7 @@ check_forked() {
 				fi
 				dist_version="$(sed 's/\/.*//' /etc/debian_version | sed 's/\..*//')"
 				case "$dist_version" in
-					13)
+					13|14|forky)
 						dist_version="trixie"
 					;;
 					12)


### PR DESCRIPTION
forky dist is not deployed, so use trixie instead.

This is similar to #327.
