### PR TITLE
deploy: Add /repo endpoint for repository-only setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ ENVSUBST_VARS=LOAD_SCRIPT_COMMIT_SHA LOAD_SCRIPT_STABLE_LATEST LOAD_SCRIPT_TEST_
 # Define the channels we want to build for
 CHANNELS=test stable
 
-FILES=build/test/install.sh build/stable/install.sh build/stable/rootless-install.sh
+FILES=build/test/install.sh build/stable/install.sh build/stable/rootless-install.sh build/stable/setup-repo.sh
 
 STABLE_LATEST=$(shell ./scripts/get-version.sh stable)
 TEST_LATEST=$(shell ./scripts/get-version.sh test)
@@ -45,6 +45,16 @@ build/%/rootless-install.sh: rootless-install.sh
 		envsubst '$(addprefix $$,$(ENVSUBST_VARS))' > $@
 	chmod +x $@
 
+build/%/setup-repo.sh: install.sh
+	mkdir -p $(@D)
+	sed -e 's/DEFAULT_CHANNEL_VALUE="stable"/DEFAULT_CHANNEL_VALUE="$*"/' \
+		-e 's/REPO_ONLY=$${REPO_ONLY:-0}/REPO_ONLY=$${REPO_ONLY:-1}/' $< | \
+		LOAD_SCRIPT_COMMIT_SHA='$(shell git rev-parse HEAD)' \
+		LOAD_SCRIPT_STABLE_LATEST='$(STABLE_LATEST)' \
+		LOAD_SCRIPT_TEST_LATEST='$(TEST_LATEST)' \
+		envsubst '$(addprefix $$,$(ENVSUBST_VARS))' > $@
+	chmod +x $@
+
 .PHONY: shellcheck
 shellcheck: $(FILES)
 	$(SHELLCHECK) $^
@@ -72,7 +82,7 @@ AWS?=docker run \
 	--rm amazon/aws-cli
 
 .PHONY: deploy
-deploy: build/$(CHANNEL)/install.sh build/$(CHANNEL)/rootless-install.sh
+deploy: build/$(CHANNEL)/install.sh build/$(CHANNEL)/rootless-install.sh build/$(CHANNEL)/setup-repo.sh
 ifeq ($(S3_BUCKET),)
 	$(error S3_BUCKET is empty.)
 endif
@@ -85,12 +95,13 @@ endif
 	$(AWS) s3 cp --acl public-read --content-type 'text/plain' /build/$(CHANNEL)/install.sh s3://$(S3_BUCKET)/index
 ifeq ($(CHANNEL),stable)
 	$(AWS) s3 cp --acl public-read --content-type 'text/plain' /build/$(CHANNEL)/rootless-install.sh s3://$(S3_BUCKET)/rootless
+	$(AWS) s3 cp --acl public-read --content-type 'text/plain' /build/$(CHANNEL)/setup-repo.sh s3://$(S3_BUCKET)/repo
 endif
 
 	$(AWS) cloudfront create-invalidation --distribution-id $(CF_DISTRIBUTION_ID) --paths '/*'
 
 .PHONY: diff
-diff: build/$(CHANNEL)/install.sh build/$(CHANNEL)/rootless-install.sh
+diff: build/$(CHANNEL)/install.sh build/$(CHANNEL)/rootless-install.sh build/$(CHANNEL)/setup-repo.sh
 ifeq ($(CHANNEL),)
 	$(error CHANNEL is empty.)
 endif

--- a/README.md
+++ b/README.md
@@ -29,6 +29,17 @@ From the source repo (This will install latest from the `stable` channel):
 sh install.sh
 ```
 
+### Repository Setup Only
+
+To configure Docker's package repositories without installing Docker packages,
+use the `/repo` endpoint:
+
+```shell
+curl -fsSL https://get.docker.com/repo | sh -
+```
+
+This is equivalent to running `sh install.sh --setup-repo`.
+
 ## Testing:
 
 To verify that the install script works amongst the supported operating systems run:

--- a/diff.sh
+++ b/diff.sh
@@ -35,6 +35,11 @@ if [[ "$CHANNEL" == "stable" ]] && [[ ! -f "build/$CHANNEL/rootless-install.sh" 
     exit 1
 fi
 
+if [[ "$CHANNEL" == "stable" ]] && [[ ! -f "build/$CHANNEL/setup-repo.sh" ]]; then
+    echo "Error: build/$CHANNEL/setup-repo.sh not found" >&2
+    exit 1
+fi
+
 TMP_DIR=$(mktemp -d)
 
 # Download and compare install.sh
@@ -45,11 +50,17 @@ if ! diff -u "$TMP_DIR/install.sh" "build/$CHANNEL/install.sh"; then
     DIFF_FOUND=1
 fi
 
-# For stable channel, also compare rootless-install.sh
+# For stable channel, also compare rootless-install.sh and setup-repo.sh
 if [[ "$CHANNEL" == "stable" ]]; then
     curl -sfSL "https://$SUBDOMAIN.docker.com/rootless" -o "$TMP_DIR/rootless-install.sh"
     echo "# Diff $CHANNEL rootless-install.sh"
     if ! diff -u "$TMP_DIR/rootless-install.sh" "build/$CHANNEL/rootless-install.sh"; then
+        DIFF_FOUND=1
+    fi
+
+    curl -sfSL "https://$SUBDOMAIN.docker.com/repo" -o "$TMP_DIR/setup-repo.sh"
+    echo "# Diff $CHANNEL setup-repo.sh"
+    if ! diff -u "$TMP_DIR/setup-repo.sh" "build/$CHANNEL/setup-repo.sh"; then
         DIFF_FOUND=1
     fi
 fi


### PR DESCRIPTION
Add a new /repo endpoint (get.docker.com/repo) that configures Docker's package repositories without installing Docker packages.

This is the same install.sh just with REPO_ONLY defaulting to 1, equivalent to running install.sh --setup-repo.

This allows to do:
```
curl -s https://get.docker.com/repo | sudo sh -
```

instead of:

```
curl -s https://get.docker.com | sudo sh -s -- --setup-repo
# or
curl -s https://get.docker.com | sudo REPO_ONLY=1 sh -
```

For the last one, it's especially tricky because there's a difference between:
```
# good
sudo REPO_ONLY=1 sh -
and
# bad, sudo would need -E to preserve env
REPO_ONLY=1 sudo sh -
```