### PR TITLE
install.sh: Actually start Docker daemon via systemctl

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -301,7 +301,7 @@ start_docker_daemon() {
 		is_dry_run || >&2 echo "Using systemd to manage Docker service"
 		if (
 			is_dry_run || set -x
-			$sh_c systemctl enable --now docker.service 2>/dev/null
+			$sh_c "systemctl enable --now docker.service 2>/dev/null"
 		); then
 			is_dry_run || echo "INFO: Docker daemon enabled and started" >&2
 		else


### PR DESCRIPTION
Installing on fresh Fedora 43 Server Edition using `curl -fsSL https://get.docker.com | sudo bash` results in a disabled Docker service. The installation script also outputs a meaningless list of all units during installation. It happens because it runs `sh -c systemctl enable --now docker.service` instead of `sh -c "systemctl enable --now docker.service"` - and only bare systemctl command is executed without the parameters. This commit fixes this behaviour.