### PR TITLE
install: Use RHEL repo for Rocky Linux

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -631,7 +631,11 @@ do_install() {
 				echo "Effective v27.5, please consult RHEL distro statement for s390x support."
 				exit 1
 			fi
-			repo_file_url="$DOWNLOAD_URL/linux/$lsb_dist/$REPO_FILE"
+			if [ "$lsb_dist" = rocky ]; then
+			    repo_file_url="$DOWNLOAD_URL/linux/rhel/$REPO_FILE"
+			else
+			    repo_file_url="$DOWNLOAD_URL/linux/$lsb_dist/$REPO_FILE"
+			fi
 			(
 				if ! is_dry_run; then
 					set -x


### PR DESCRIPTION
86f94af03 added Rocky Linux as a recognized distro and thus the script sets up the repo[0]. However the repo doesn't currently contain the required packages, and thus the installation fails.

Rocky being fully compatible with RHEL, using its repo leads to a working installation. This aligns with the current advice from Rocky's own docs[1].

Fixes #264 #373 #468 #469

[0]: https://download.docker.com/linux/rocky/
[1]: https://docs.rockylinux.org/10/gemstones/containers/docker/

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Add a test changing the value of `$repo_file_url` when rocky is detected to use rhel repo instead.

**- How I did it**

Thinking a bit and writing as much

**- How to verify it**

By reading the code?

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
install: improve Rocky Linux support

**- A picture of a cute animal (not mandatory but encouraged)**

![](https://www.rd.com/wp-content/uploads/2021/04/GettyImages-1145794687.jpg)
