### PR TITLE
rootless-install: use docker-29.4.2-2.tgz for version 29.4.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
           - quay.io/centos/centos:stream9
         version:
           - "27.5"
+          - "29.4.2"
           - ""
 
     steps:
@@ -31,6 +32,14 @@ jobs:
   test-install-rootless:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    strategy:
+      matrix:
+        channel:
+          - test
+          - stable
+        include:
+          - channel: stable
+            stable_latest: "29.4.2"
     steps:
     - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
     - name: Install rootless
@@ -38,6 +47,6 @@ jobs:
         GH_TOKEN: ${{ github.token }}
       run: |
         sudo sh -c 'echo 0 > /proc/sys/kernel/apparmor_restrict_unprivileged_userns'
-        make build/test/rootless-install.sh
-        FORCE_ROOTLESS_INSTALL=1 ./build/test/rootless-install.sh
-    
+        make build/${{ matrix.channel }}/rootless-install.sh \
+          ${{ matrix.stable_latest && format('STABLE_LATEST={0}', matrix.stable_latest) || '' }}
+        FORCE_ROOTLESS_INSTALL=1 ./build/${{ matrix.channel }}/rootless-install.sh

--- a/rootless-install.sh
+++ b/rootless-install.sh
@@ -36,16 +36,32 @@ fi
 
 STATIC_RELEASE_URL=
 STATIC_RELEASE_ROOTLESS_URL=
+
+# static_release_url returns the download URL for a given package and version.
+# Some releases use a different tarball name than the version number (e.g. a
+# re-release with a suffix), which is handled here.
+# Usage: static_release_url <docker|docker-rootless-extras> <version>
+static_release_url() {
+	case "$2" in
+		29.4.2)
+			echo "https://download.docker.com/linux/static/$CHANNEL/$(uname -m)/$1-29.4.2-2.tgz"
+			;;
+		*)
+			echo "https://download.docker.com/linux/static/$CHANNEL/$(uname -m)/$1-$2.tgz"
+			;;
+	esac
+}
+
 case "$CHANNEL" in
     "stable")
         echo "# Installing stable version ${STABLE_LATEST}"
-        STATIC_RELEASE_URL="https://download.docker.com/linux/static/$CHANNEL/$(uname -m)/docker-${STABLE_LATEST}.tgz"
-        STATIC_RELEASE_ROOTLESS_URL="https://download.docker.com/linux/static/$CHANNEL/$(uname -m)/docker-rootless-extras-${STABLE_LATEST}.tgz"
+        STATIC_RELEASE_URL=$(static_release_url docker "$STABLE_LATEST")
+        STATIC_RELEASE_ROOTLESS_URL=$(static_release_url docker-rootless-extras "$STABLE_LATEST")
         ;;
     "test")
         echo "# Installing test version ${TEST_LATEST}"
-        STATIC_RELEASE_URL="https://download.docker.com/linux/static/$CHANNEL/$(uname -m)/docker-${TEST_LATEST}.tgz"
-        STATIC_RELEASE_ROOTLESS_URL="https://download.docker.com/linux/static/$CHANNEL/$(uname -m)/docker-rootless-extras-${TEST_LATEST}.tgz"
+        STATIC_RELEASE_URL=$(static_release_url docker "$TEST_LATEST")
+        STATIC_RELEASE_ROOTLESS_URL=$(static_release_url docker-rootless-extras "$TEST_LATEST")
         ;;
     *)
         >&2 echo "Aborting because of unknown CHANNEL \"$CHANNEL\". Set \$CHANNEL to either \"stable\" or \"test\"."


### PR DESCRIPTION
The static binary tarball for Docker 29.4.2 was re-released with a "-2" suffix. Add a static_release_version() helper that maps version numbers to their actual tarball name, so that 29.4.2 resolves to docker-29.4.2-2.tgz instead of docker-29.4.2.tgz.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

