### PR TITLE
install: Deprecate Fedora < 43

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -547,7 +547,7 @@ do_install() {
 			deprecation_notice "$lsb_dist" "$dist_version"
 			;;
 		fedora.*)
-			if [ "$dist_version" -lt 41 ]; then
+			if [ "$dist_version" -lt 43 ]; then
 				deprecation_notice "$lsb_dist" "$dist_version"
 			fi
 			;;


### PR DESCRIPTION
Fedora versions older than 43 are now EOL for this installer path.

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/docker/cli/blob/master/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

For additional information on our contributing process, read our contributing
guide https://docs.docker.com/opensource/code/

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

