### PR TITLE
scripts/get-version: Select stable release for test when newer

### DIFF
--- a/scripts/get-version.sh
+++ b/scripts/get-version.sh
@@ -21,7 +21,7 @@ last_release_tag() {
 
 case "$channel" in
     stable) last_release_tag 'isLatest' ;;
-    test) last_release_tag 'isPrerelease' ;;
+    test) last_release_tag 'isPrerelease or .isLatest' ;;
     *)
         echo "Error: Invalid channel '$channel'. Use 'stable' or 'test'." >&2
         exit 1


### PR DESCRIPTION
The release list is already ordered newest first, so the test channel only needs to consider releases that are either prereleases or the latest stable release.
This keeps test from resolving to an older prerelease after a newer stable release is published.