### PR TITLE
fix: use Debian repo for Raspbian Trixie

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -557,7 +557,12 @@ do_install() {
 	case "$lsb_dist" in
 		ubuntu|debian|raspbian)
 			pre_reqs="ca-certificates curl"
-			apt_repo="deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] $DOWNLOAD_URL/linux/$lsb_dist $dist_version $CHANNEL"
+			apt_repo_lsb_dist="$lsb_dist"
+			# Docker does not publish a Raspbian Trixie repo; use Debian Trixie instead.
+			if [ "$lsb_dist" = "raspbian" ] && [ "$dist_version" = "trixie" ]; then
+				apt_repo_lsb_dist="debian"
+			fi
+			apt_repo="deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] $DOWNLOAD_URL/linux/$apt_repo_lsb_dist $dist_version $CHANNEL"
 			(
 				if ! is_dry_run; then
 					set -x
@@ -565,7 +570,7 @@ do_install() {
 				$sh_c 'apt-get -qq update >/dev/null'
 				$sh_c "DEBIAN_FRONTEND=noninteractive apt-get -y -qq install $pre_reqs >/dev/null"
 				$sh_c 'install -m 0755 -d /etc/apt/keyrings'
-				$sh_c "curl -fsSL \"$DOWNLOAD_URL/linux/$lsb_dist/gpg\" -o /etc/apt/keyrings/docker.asc"
+				$sh_c "curl -fsSL \"$DOWNLOAD_URL/linux/$apt_repo_lsb_dist/gpg\" -o /etc/apt/keyrings/docker.asc"
 				$sh_c "chmod a+r /etc/apt/keyrings/docker.asc"
 				$sh_c "echo \"$apt_repo\" > /etc/apt/sources.list.d/docker.list"
 				$sh_c 'apt-get -qq update >/dev/null'


### PR DESCRIPTION
**- What I did**

Closes #542. For Raspbian/Raspberry Pi OS Trixie, `install.sh` now uses Docker's Debian Trixie APT repository and GPG key path instead of the non-existent `linux/raspbian trixie` repository. Existing Raspbian releases with published Docker Raspbian repositories stay unchanged.

**- How I did it**

The script keeps `lsb_dist=raspbian` for detection and release handling, but uses a separate repository distro variable when building the APT repo and key URL. That variable is mapped to `debian` only for `raspbian` + `trixie`.

**- How to verify it**

I ran:

```sh
git diff --check
sh -n install.sh
/tmp/github-contribute-docker-docker-install-542/verify-raspbian-repo.sh ./install.sh
```

The focused dry-run harness verified simulated Raspbian `13` emits `https://download.docker.com/linux/debian trixie stable` and `https://download.docker.com/linux/debian/gpg`, with no `linux/raspbian trixie` entry. It also verified simulated Raspbian `12` still emits `https://download.docker.com/linux/raspbian bookworm stable` and `https://download.docker.com/linux/raspbian/gpg`.

I also checked Docker's Debian Trixie package indexes return 200 for `binary-armhf`, `binary-arm64`, and `binary-amd64`.

**- Description for the changelog**

Use Debian APT repositories for Raspbian Trixie installs.

**- A picture of a cute animal (not mandatory but encouraged)**

Not included.
