### PR TITLE
minor cleanups and fixes

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -595,21 +595,22 @@ do_install() {
 					# Will work for incomplete versions IE (17.12), but may not actually grab the "latest" if in the test channel
 					pkg_pattern="$(echo "$VERSION" | sed 's/-ce-/~ce~.*/g' | sed 's/-/.*/g')"
 					search_command="apt-cache madison docker-ce | grep '$pkg_pattern' | head -1 | awk '{\$1=\$1};1' | cut -d' ' -f 3"
-					pkg_version="$($sh_c "$search_command")"
 					echo "INFO: Searching repository for VERSION '$VERSION'"
 					echo "INFO: $search_command"
+					pkg_version="$($sh_c "$search_command")"
 					if [ -z "$pkg_version" ]; then
 						echo
 						echo "ERROR: '$VERSION' not found amongst apt-cache madison results"
 						echo
 						exit 1
 					fi
+					pkg_version="=$pkg_version"
+
 					if version_gte "18.09"; then
 						search_command="apt-cache madison docker-ce-cli | grep '$pkg_pattern' | head -1 | awk '{\$1=\$1};1' | cut -d' ' -f 3"
 						echo "INFO: $search_command"
 						cli_pkg_version="=$($sh_c "$search_command")"
 					fi
-					pkg_version="=$pkg_version"
 				fi
 			fi
 			(
@@ -700,22 +701,23 @@ do_install() {
 					fi
 					pkg_pattern="$(echo "$VERSION" | sed 's/-ce-/\\\\.ce.*/g' | sed 's/-/.*/g').*$pkg_suffix"
 					search_command="$pkg_manager list --showduplicates docker-ce | grep '$pkg_pattern' | tail -1 | awk '{print \$2}'"
-					pkg_version="$($sh_c "$search_command")"
 					echo "INFO: Searching repository for VERSION '$VERSION'"
 					echo "INFO: $search_command"
+					pkg_version="$($sh_c "$search_command")"
 					if [ -z "$pkg_version" ]; then
 						echo
 						echo "ERROR: '$VERSION' not found amongst $pkg_manager list results"
 						echo
 						exit 1
 					fi
+					# Cut out the epoch and prefix with a '-'
+					pkg_version="-$(echo "$pkg_version" | cut -d':' -f 2)"
+
 					if version_gte "18.09"; then
 						# older versions don't support a cli package
 						search_command="$pkg_manager list --showduplicates docker-ce-cli | grep '$pkg_pattern' | tail -1 | awk '{print \$2}'"
 						cli_pkg_version="$($sh_c "$search_command" | cut -d':' -f 2)"
 					fi
-					# Cut out the epoch and prefix with a '-'
-					pkg_version="-$(echo "$pkg_version" | cut -d':' -f 2)"
 				fi
 			fi
 			(

--- a/install.sh
+++ b/install.sh
@@ -604,9 +604,9 @@ do_install() {
 						exit 1
 					fi
 					if version_gte "18.09"; then
-							search_command="apt-cache madison docker-ce-cli | grep '$pkg_pattern' | head -1 | awk '{\$1=\$1};1' | cut -d' ' -f 3"
-							echo "INFO: $search_command"
-							cli_pkg_version="=$($sh_c "$search_command")"
+						search_command="apt-cache madison docker-ce-cli | grep '$pkg_pattern' | head -1 | awk '{\$1=\$1};1' | cut -d' ' -f 3"
+						echo "INFO: $search_command"
+						cli_pkg_version="=$($sh_c "$search_command")"
 					fi
 					pkg_version="=$pkg_version"
 				fi
@@ -614,17 +614,17 @@ do_install() {
 			(
 				pkgs="docker-ce${pkg_version%=}"
 				if version_gte "18.09"; then
-						# older versions didn't ship the cli and containerd as separate packages
-						pkgs="$pkgs docker-ce-cli${cli_pkg_version%=} containerd.io"
+					# older versions didn't ship the cli and containerd as separate packages
+					pkgs="$pkgs docker-ce-cli${cli_pkg_version%=} containerd.io"
 				fi
 				if version_gte "20.10"; then
-						pkgs="$pkgs docker-compose-plugin docker-ce-rootless-extras$pkg_version"
+					pkgs="$pkgs docker-compose-plugin docker-ce-rootless-extras$pkg_version"
 				fi
 				if version_gte "23.0"; then
-						pkgs="$pkgs docker-buildx-plugin"
+					pkgs="$pkgs docker-buildx-plugin"
 				fi
 				if version_gte "28.2"; then
-						pkgs="$pkgs docker-model-plugin"
+					pkgs="$pkgs docker-model-plugin"
 				fi
 				if ! is_dry_run; then
 					set -x

--- a/install.sh
+++ b/install.sh
@@ -587,6 +587,7 @@ do_install() {
 			fi
 
 			pkg_version=""
+			cli_pkg_version=""
 			if [ -n "$VERSION" ]; then
 				if is_dry_run; then
 					echo "# WARNING: VERSION pinning is not supported in DRY_RUN"
@@ -680,6 +681,7 @@ do_install() {
 			fi
 
 			pkg_version=""
+			cli_pkg_version=""
 			if command_exists dnf; then
 				pkg_manager="dnf"
 				pkg_manager_flags="-y -q --best"

--- a/install.sh
+++ b/install.sh
@@ -609,15 +609,18 @@ do_install() {
 					if version_gte "18.09"; then
 						search_command="apt-cache madison docker-ce-cli | grep '$pkg_pattern' | head -1 | awk '{\$1=\$1};1' | cut -d' ' -f 3"
 						echo "INFO: $search_command"
-						cli_pkg_version="=$($sh_c "$search_command")"
+						cli_pkg_version="$($sh_c "$search_command")"
+						if [ -n "$cli_pkg_version" ]; then
+							cli_pkg_version="=$cli_pkg_version"
+						fi
 					fi
 				fi
 			fi
 			(
-				pkgs="docker-ce${pkg_version%=}"
+				pkgs="docker-ce${pkg_version}"
 				if version_gte "18.09"; then
 					# older versions didn't ship the cli and containerd as separate packages
-					pkgs="$pkgs docker-ce-cli${cli_pkg_version%=} containerd.io"
+					pkgs="$pkgs docker-ce-cli${cli_pkg_version} containerd.io"
 				fi
 				if version_gte "20.10"; then
 					pkgs="$pkgs docker-compose-plugin docker-ce-rootless-extras$pkg_version"


### PR DESCRIPTION
### fix indentation

### always declare cli_pkg_version

No real impact, but `$cli_pkg_version` was used unconditionally,
but was set conditionally.

### move vars closer to where used

### prevent bare "=" as version

Make sure both pkg_version and cli_pkg_version are only set on success
to prevent them containing a bare "=", which we were stripping later on.


**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

